### PR TITLE
deploy_pip is now able to use dependencies provided via requirements specified in the BUILD file (fix #26)

### DIFF
--- a/pip/templates/deploy.sh
+++ b/pip/templates/deploy.sh
@@ -42,12 +42,43 @@ PIP_REPOSITORY_URL=$(grep "pip.repository-url.$PIP_REPO_TYPE" ${DEPLOYMENT_PROPE
 
 # needed for uploading the built package
 TWINEPATH=$(dirname $(pwd)/external/*twine*/twine/)
+# pkginfo package needed as dependency of twine
+PKGINFO_PATH=$(dirname $(pwd)/external/*pkginfo*/pkginfo/)
+# readme_renderer package needed as dependency of twine
+README_RENDERER_PATH=$(dirname $(pwd)/external/*readme_renderer*/readme_renderer/)
+# Pygments package needed as dependency of twine
+PYGMENTS_PATH=$(dirname $(pwd)/external/*Pygments*/Pygments/)
+# requests package needed as dependency of twine
+REQUESTS_PATH=$(dirname $(pwd)/external/*requests*/requests/)
+# urllib3 package needed as dependency of requests
+URLLIB3_PATH=$(dirname $(pwd)/external/*urllib3*/urllib3/)
+# chardet package needed as dependency of requests
+CHARDET_PATH=$(dirname $(pwd)/external/*chardet*/chardet/)
+# certifi package needed as dependency of requests
+CERTIFI_PATH=$(dirname $(pwd)/external/*certifi*/certifi/)
+# idna package needed as dependency of requests
+IDNA_PATH=$(dirname $(pwd)/external/*idna*/idna/)
+# tqdm package needed as dependency of requests
+TQDM_PATH=$(dirname $(pwd)/external/*tqdm*/tqdm/)
+# requests-toolbelt package needed as dependency of requests
+REQUESTS_TOOLBELT_PATH=$(dirname $(pwd)/external/*requests_toolbelt*/requests_toolbelt/)
+# six package needed as dependency of readme-renderer
+SIX_PATH="$(dirname $(pwd)/external/*six*/six.py)"
+# docutils package needed as dependency of readme-renderer
+DOCUTILS_PATH=$(dirname $(pwd)/external/*docutils*/docutils/)
+# bleach package needed as dependency of readme-renderer
+BLEACH_PATH=$(dirname $(pwd)/external/*bleach*/bleach/)
+# webencodings package needed as dependency of readme-renderer
+WEBENCODINGS_PATH=$(dirname $(pwd)/external/*webencodings*/webencodings/)
+
 # needed for bdist_wheel
 WHEELPATH=$(dirname $(pwd)/external/*wheel*/wheel/)
 # updated 'setuptools' package needed for supporting Markdown in README
 SETUPTOOLS_PATH=$(dirname $(pwd)/external/*setuptools*/setuptools/)
 
-export PYTHONPATH="$TWINEPATH:$WHEELPATH:$SETUPTOOLS_PATH"
+export PYTHONPATH="$TWINEPATH:$PKGINFO_PATH:$REQUESTS_PATH:$WEBENCODINGS_PATH:$SIX_PATH:$DOCUTILS_PATH:"\
+"$BLEACH_PATH:$URLLIB3_PATH:$SIX_PATH:$README_RENDERER_PATH:$PYGMENTS_PATH:$CHARDET_PATH:"\
+"$CERTIFI_PATH:$IDNA_PATH:$TQDM_PATH:$REQUESTS_TOOLBELT_PATH:$WHEELPATH:$SETUPTOOLS_PATH"
 TWINE_BINARY="python $(pwd)/external/*twine*/twine/__main__.py"
 
 # Replace with package root in rule


### PR DESCRIPTION
# Why is this PR needed?
The `deploy_pip()` rule expects a certain set of libraries to be installed system-wide or it will fail to execute otherwise. You can't provide them via a `BUILD` file.

This isn't ideal as the Bazel approach is that you're supposed to declare transitive dependencies in the `BUILD` file.

Specifically, the aforementioned "set of libraries" are libraries needed by `twine`, which is used internally by `deploy_pip()`.

I had those dependencies installed system-wide on my machine, which is why the problem only manifests when James tried to run the command on the CI machine and on his computer.

# What does the PR do?
Made `deploy_pip()` able to read that set of libraries from the `BUILD` file so they don't have to be installed system-wide on that machine.

# Does it break backwards compatibility?
—

# List of future improvements not on this PR
N/A