### PR TITLE
add `deps` attribute to deploy_pip

### DIFF
--- a/pip/BUILD
+++ b/pip/BUILD
@@ -16,4 +16,4 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-exports_files(["replace_imports.py"])
+exports_files(["replace_imports.py", "requirements.txt"])

--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -1,0 +1,16 @@
+Pygments==2.3.1
+bleach==3.1.0
+certifi==2018.11.29
+chardet==3.0.4
+docutils==0.14
+idna==2.8
+pkginfo==1.5.0.1
+readme-renderer==24.0
+requests-toolbelt==0.8.0
+requests==2.21.0
+setuptools>=38.6.0
+tqdm==4.29.1
+twine==1.12.1
+urllib3==1.24.1
+webencodings==0.5.1
+wheel==0.32.3

--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -60,13 +60,18 @@ def _deploy_pip_impl(ctx):
       is_executable = True
   )
 
+  all_python_files = []
+  for dep in ctx.attr.deps:
+    all_python_files.extend(dep.data_runfiles.files.to_list())
+    all_python_files.extend(dep.default_runfiles.files.to_list())
+
   return DefaultInfo(executable = ctx.outputs.deployment_script,
                      runfiles = ctx.runfiles(
                          files = [
                             ctx.file.deployment_properties,
                             ctx.outputs.setup_py,
                             ctx.file.long_description_file
-                         ],
+                         ] + all_python_files,
                          symlinks = {
                              "deployment.properties": ctx.file.deployment_properties
                          }).merge(ctx.attr.target.default_runfiles))
@@ -146,6 +151,9 @@ deploy_pip = rule(
     "install_requires": attr.string_list(
         mandatory = True,
         doc = "A list of strings which are names of required packages for this one"
+    ),
+    "deps": attr.label_list(
+        mandatory = True
     ),
     "_setup_py_template": attr.label(
         allow_single_file = True,

--- a/pip/templates/deploy.sh
+++ b/pip/templates/deploy.sh
@@ -47,7 +47,7 @@ PKGINFO_PATH=$(dirname $(pwd)/external/*pkginfo*/pkginfo/)
 # readme_renderer package needed as dependency of twine
 README_RENDERER_PATH=$(dirname $(pwd)/external/*readme_renderer*/readme_renderer/)
 # Pygments package needed as dependency of twine
-PYGMENTS_PATH=$(dirname $(pwd)/external/*Pygments*/Pygments/)
+PYGMENTS_PATH=$(dirname $(pwd)/external/*Pygments*/pygments/)
 # requests package needed as dependency of twine
 REQUESTS_PATH=$(dirname $(pwd)/external/*requests*/requests/)
 # urllib3 package needed as dependency of requests
@@ -79,6 +79,7 @@ SETUPTOOLS_PATH=$(dirname $(pwd)/external/*setuptools*/setuptools/)
 export PYTHONPATH="$TWINEPATH:$PKGINFO_PATH:$REQUESTS_PATH:$WEBENCODINGS_PATH:$SIX_PATH:$DOCUTILS_PATH:"\
 "$BLEACH_PATH:$URLLIB3_PATH:$SIX_PATH:$README_RENDERER_PATH:$PYGMENTS_PATH:$CHARDET_PATH:"\
 "$CERTIFI_PATH:$IDNA_PATH:$TQDM_PATH:$REQUESTS_TOOLBELT_PATH:$WHEELPATH:$SETUPTOOLS_PATH"
+
 TWINE_BINARY="python $(pwd)/external/*twine*/twine/__main__.py"
 
 # Replace with package root in rule

--- a/pip/templates/deploy.sh
+++ b/pip/templates/deploy.sh
@@ -63,7 +63,7 @@ TQDM_PATH=$(dirname $(pwd)/external/*tqdm*/tqdm/)
 # requests-toolbelt package needed as dependency of requests
 REQUESTS_TOOLBELT_PATH=$(dirname $(pwd)/external/*requests_toolbelt*/requests_toolbelt/)
 # six package needed as dependency of readme-renderer
-SIX_PATH="$(dirname $(pwd)/external/*six*/six.py)"
+SIX_PATH="$(dirname $(pwd)/external/pypi__six_1_12_0/six.py)"
 # docutils package needed as dependency of readme-renderer
 DOCUTILS_PATH=$(dirname $(pwd)/external/*docutils*/docutils/)
 # bleach package needed as dependency of readme-renderer


### PR DESCRIPTION
Adds `deps` to `deploy_pip` rule which expects you to pass all deps that are required for deployment to `pip`