### PR TITLE
Fix npm deployment for targets at root package (i.e. //:target)

### DIFF
--- a/npm/templates/deploy.sh
+++ b/npm/templates/deploy.sh
@@ -37,7 +37,7 @@ NPM_REPOSITORY_URL=$(grep "npm.repository-url" ${DEPLOYMENT_PROPERTIES_STRIPPED_
 
 export PATH="$(dirname $(readlink external/nodejs/bin/nodejs/bin/npm)):$PATH"
 export VERSION="{version}"
-cd "$BAZEL_PACKAGE_NAME/$BAZEL_TARGET_NAME"
+cd "./$BAZEL_PACKAGE_NAME/$BAZEL_TARGET_NAME"
 
 chmod a+w .
 sed -i '' "s/0.0.0-development/$VERSION/g" package.json


### PR DESCRIPTION
For targets at root package, `$BAZEL_PACKAGE_NAME` is empty and therefore directory to `cd` in expands into incorrect one

Before:
`//client-nodejs:deploy-npm` → `client-nodejs/deploy-npm`
`//:deploy-npm` → `/deploy-npm`

After:
`//client-nodejs:deploy-npm` → `./client-nodejs/deploy-npm`
`//:deploy-npm` → `.//deploy-npm`