### PR TITLE
Fix pip deployment

### DIFF
--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -54,9 +54,7 @@ def _deploy_pip_impl(ctx):
   ctx.actions.expand_template(
       template = ctx.file._deployment_script_template,
       output = ctx.outputs.deployment_script,
-      substitutions = {
-          "$PKG_DIR": ctx.attr.target.label.package
-      },
+      substitutions = {},
       is_executable = True
   )
 

--- a/pip/templates/deploy.sh
+++ b/pip/templates/deploy.sh
@@ -82,9 +82,6 @@ export PYTHONPATH="$TWINEPATH:$PKGINFO_PATH:$REQUESTS_PATH:$WEBENCODINGS_PATH:$S
 
 TWINE_BINARY="python $(pwd)/external/*twine*/twine/__main__.py"
 
-# Replace with package root in rule
-cd "$PKG_DIR"
-
 # clean up previous distribution files
 rm -fv dist/*
 python setup.py sdist


### PR DESCRIPTION
* `cd`-ing into directory breaks [graknlabs/kglib](https://github.com/graknlabs/kglib) deployment
* not `cd`-ing into directory _does not_ break [graknlabs/client_python](https://github.com/graknlabs/client_python), because `$PKG_DIR` is `''` for `//:client_python` anyway