### PR TITLE
BUGFIX: replace duplicate workspace name if rule is user from other repo

### DIFF
--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -1,7 +1,12 @@
 def _py_replace_imports_impl(ctx):
     outputs = []
     for file in ctx.files.src:
-        relativeFileName = file.short_path.replace(ctx.attr.src.label.package + '/', '')
+        relativeFileName = file.short_path
+        if not file.short_path.startswith('../'):
+            relativeFileName = relativeFileName.replace(ctx.attr.src.label.package + '/', '')
+        else:
+            _, workspaceName = ctx.attr.src.label.workspace_root.split('/')
+            relativeFileName = relativeFileName.replace(workspaceName + '/', '')
         outputFileName = relativeFileName.replace(ctx.attr.src.label.name, ctx.attr.name)
         outputFile = ctx.actions.declare_file(outputFileName)
         outputs.append(outputFile)


### PR DESCRIPTION
When `py_replace_imports` is used indirectly, it needs to replace workspace name which is duplicated twice in `file.short_path`

This fixes this error:
```
Output artifact 'external/graknlabs_client_python/graknlabs_client_python/rpc/protocol/session/Session_pb2.py' not under package directory 'external/graknlabs_client_python/grakn' for target '@graknlabs_client_python//grakn:rpc'
```