### PR TITLE
Bugfixes for building distribution on Windows

### DIFF
--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -16,4 +16,16 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-exports_files(["archiver.py", "java_deps.py", "tgz2zip.py"])
+exports_files(["archiver.py"])
+
+py_binary(
+    name = "java_deps",
+    srcs = ["java_deps.py"],
+    visibility = ["//visibility:public"]
+)
+
+py_binary(
+    name = "tgz2zip",
+    srcs = ["tgz2zip.py"],
+    visibility = ["//visibility:public"]
+)

--- a/distribution/java_deps.py
+++ b/distribution/java_deps.py
@@ -20,10 +20,12 @@
 
 from __future__ import print_function
 import tarfile
+import json
 
 import sys
-_, moves, distribution_tgz_location = sys.argv
-moves = eval(moves)
+_, moves_file_location, distribution_tgz_location = sys.argv
+with open(moves_file_location) as moves_file:
+    moves = json.load(moves_file)
 
 with tarfile.open(distribution_tgz_location, 'w:gz', dereference=True) as tgz:
     for fn, arcfn in moves.items():


### PR DESCRIPTION
* `java_deps` and `tgz2zip` are now real Bazel targets instead of exported Python scripts
* pass jar file mapping in a file instead of cmdline argument to avoid hitting limits on Windows