### PR TITLE
Use cross-platform options for 'sed'; fixes deploy_npm rule on Linux

### DIFF
--- a/npm/templates/deploy.sh
+++ b/npm/templates/deploy.sh
@@ -41,7 +41,7 @@ export VERSION="{version}"
 cd "./$BAZEL_PACKAGE_NAME/$BAZEL_TARGET_NAME"
 
 chmod a+w .
-sed -i '' "s/0.0.0-development/$VERSION/g" package.json
+sed -i.bak -e "s/0.0.0-development/$VERSION/g" package.json && rm package.json.bak
 
 # Log in to `npm`
 /usr/bin/expect <<EOD


### PR DESCRIPTION
Based on https://unix.stackexchange.com/a/92907