### PR TITLE
Fix version for deploy_pip

### DIFF
--- a/pip/templates/deploy.sh
+++ b/pip/templates/deploy.sh
@@ -82,6 +82,9 @@ export PYTHONPATH="$TWINEPATH:$PKGINFO_PATH:$REQUESTS_PATH:$WEBENCODINGS_PATH:$S
 
 TWINE_BINARY="python $(pwd)/external/*twine*/twine/__main__.py"
 
+GIT_COMMIT_HASH="$(git -C ${BUILD_WORKSPACE_DIRECTORY} rev-parse HEAD)"
+sed -i.bak -e "s/SNAPSHOT/$GIT_COMMIT_HASH/g" setup.py && rm -f setup.py.bak
+
 # clean up previous distribution files
 rm -fv dist/*
 python setup.py sdist


### PR DESCRIPTION
Similarly to #55:

`SNAPSHOT` in version is replaced with actual commit SHA1 of the repo
