### PR TITLE
prevent deployment credential from being exposed

### DIFF
--- a/apt/templates/deploy.sh
+++ b/apt/templates/deploy.sh
@@ -18,7 +18,7 @@
 
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 if [[ $# -ne 3 ]]; then
     echo "Should pass <test> <deb-username> <deb-password> as arguments"

--- a/maven/templates/deploy.sh
+++ b/maven/templates/deploy.sh
@@ -18,7 +18,7 @@
 
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 ARTIFACT="$ARTIFACT"
 COORDINATES="$COORDINATES"

--- a/npm/templates/deploy.sh
+++ b/npm/templates/deploy.sh
@@ -18,7 +18,7 @@
 
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 if [[ $# -ne 4 ]]; then
     echo "Should pass <npmjs|test> <npm-username> <npm-password> <npm-email> as arguments"

--- a/pip/templates/deploy.sh
+++ b/pip/templates/deploy.sh
@@ -18,7 +18,7 @@
 
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 if [[ $# -ne 3 ]]; then
     echo "Should pass <pypi|test|tpypi> <pip-username> <pip-password> as arguments"

--- a/rpm/templates/deploy.sh
+++ b/rpm/templates/deploy.sh
@@ -18,7 +18,7 @@
 
 #!/usr/bin/env bash
 
-set -ex
+set -e
 
 if [[ $# -ne 3 ]]; then
     echo "Should pass <test> <rpm-username> <rpm-password> as arguments"


### PR DESCRIPTION
1. make method name clearer that it contains credentials, for the eyes of developers
2. prevent grabl credential from being exposed in print statements