### PR TITLE
Use output_filename while choosing name for assemble_targz output

### DIFF
--- a/common/rules.bzl
+++ b/common/rules.bzl
@@ -97,7 +97,7 @@ def assemble_targz(name,
                    permissions = {},
                    visibility = ["//visibility:private"]):
     pkg_tar(
-        name = "{}__do_not_reference__targz".format(name),
+        name = "{}__do_not_reference__targz_0".format(name),
         deps = targets,
         extension = "tar.gz",
         files = additional_files,
@@ -106,10 +106,19 @@ def assemble_targz(name,
     )
 
     pkg_tar(
-        name = name,
-        deps = [":{}__do_not_reference__targz".format(name)],
+        name = "{}__do_not_reference__targz_1".format(name),
+        deps = [":{}__do_not_reference__targz_0".format(name)],
         package_dir = output_filename,
-        extension = "tar.gz",
+        extension = "tar.gz"
+    )
+
+    output_filename = output_filename or name
+
+    native.genrule(
+        name = name,
+        srcs = [":{}__do_not_reference__targz_1".format(name)],
+        cmd = "cp $$(echo $(SRCS) | awk '{print $$1}') $@",
+        outs = [output_filename + ".tar.gz"],
         visibility = visibility
     )
 


### PR DESCRIPTION
## What is the goal of this PR?

Fixes #67

## What are the changes implemented in this PR?

Rewrites `assemble_targz` macro in such a way that it produces a meaningful output file
Examples:

`//:assemble-linux-targz` -> `bazel-genfiles/grakn-core-all-linux.tar.gz`
`//server:assemble-linux-targz` -> `bazel-genfiles/server/grakn-core-server.tar.gz`
`//console:assemble-linux-targz` -> `bazel-genfiles/console/grakn-core-console.tar.gz`
`//bin:assemble-bash-targz` -> `bazel-genfiles/bin/assemble-bash-targz.tar.gz`