### PR TITLE
Fix broken deploy_rpm rule

### DIFF
--- a/rpm/rules.bzl
+++ b/rpm/rules.bzl
@@ -82,12 +82,14 @@ def assemble_rpm(name,
             ":osx_build": "/usr/local/bin/rpmbuild",
         })
     )
+    tag = "rpm_package_name={}".format(spec_file.split(':')[-1].replace('.spec', ''))
 
     native.genrule(
         name = name,
         srcs = ["{}__do_not_reference__rpm".format(name)],
         cmd = "cp $$(echo $(SRCS) | awk '{print $$1}') $@",
-        outs = [package_name + ".rpm"]
+        outs = [package_name + ".rpm"],
+        tags = [tag]
     )
 
 
@@ -98,8 +100,8 @@ RpmInfo = provider(
 )
 
 def _collect_rpm_package_name(target, ctx):
-    spec_filename = ctx.rule.attr.spec_file.label.name
-    package_name = spec_filename.replace('.spec', '')
+    rpm_tag = ctx.rule.attr.tags[0]
+    package_name = rpm_tag.replace('rpm_package_name=', '')
     return RpmInfo(package_name=package_name)
 
 


### PR DESCRIPTION
## What is the goal of this PR?

Fix `deploy_rpm` bug (closes #70)

## What are the changes implemented in this PR?

Previously `deploy_rpm` was expecting to get `pkg_rpm` target, specifically, for `_collect_rpm_package_name` aspect to read `spec_file`. Since `deploy_rpm` now takes the output of `assemble_rpm`, which is a `genrule`, we add a proper tag to output target of `assemble_rpm` and configure aspect to read from that tag instead