### PR TITLE
Fix naming for Maven JARs inside distributions

### DIFF
--- a/common/java_deps.py
+++ b/common/java_deps.py
@@ -23,10 +23,13 @@ import tarfile
 import json
 
 import sys
-_, moves_file_location, distribution_tgz_location = sys.argv
+_, moves_file_location, distribution_tgz_location, version_file_location = sys.argv
 with open(moves_file_location) as moves_file:
     moves = json.load(moves_file)
 
+with open(version_file_location) as version_file:
+    version = version_file.read().strip()
+
 with tarfile.open(distribution_tgz_location, 'w:gz', dereference=True) as tgz:
     for fn, arcfn in moves.items():
-        tgz.add(fn, arcfn)
+        tgz.add(fn, arcfn.replace('{pom_version}', version))

--- a/common/rules.bzl
+++ b/common/rules.bzl
@@ -1,17 +1,107 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
 
 LOCAL_JDK_PREFIX = "external/local_jdk/"
+MAVEN_COORDINATES_PREFIX = "maven_coordinates="
+
+# mapping of single JAR to its Maven coordinates
+JarToMavenCoordinatesMapping = provider(
+    fields = {
+        "filename": "jar filename",
+        "maven_coordinates" : "Maven coordinates of the jar"
+    },
+)
+
+# mapping of all JARs to their Maven coordinates
+TransitiveJarToMavenCoordinatesMapping = provider(
+    fields = {
+        'mapping': 'maps jar filename to coordinates'
+    }
+)
+
+def _transitive_collect_maven_coordinate_impl(_target, ctx):
+    mapping = {}
+
+    if JarToMavenCoordinatesMapping in _target:
+        mapping[_target[JarToMavenCoordinatesMapping].filename] = _target[
+            JarToMavenCoordinatesMapping].maven_coordinates
+
+    for dep in getattr(ctx.rule.attr, "jars", []):
+        if TransitiveJarToMavenCoordinatesMapping in dep:
+            mapping.update(dep[TransitiveJarToMavenCoordinatesMapping].mapping)
+    for dep in getattr(ctx.rule.attr, "deps", []):
+        if TransitiveJarToMavenCoordinatesMapping in dep:
+            mapping.update(dep[TransitiveJarToMavenCoordinatesMapping].mapping)
+    for dep in getattr(ctx.rule.attr, "exports", []):
+        if TransitiveJarToMavenCoordinatesMapping in dep:
+            mapping.update(dep[TransitiveJarToMavenCoordinatesMapping].mapping)
+    for dep in getattr(ctx.rule.attr, "runtime_deps", []):
+        if TransitiveJarToMavenCoordinatesMapping in dep:
+            mapping.update(dep[TransitiveJarToMavenCoordinatesMapping].mapping)
+
+    # don't store jars with no attached Maven coordinates
+    cleaned_mapping = {k: v for k,v in mapping.items() if v}
+    return [TransitiveJarToMavenCoordinatesMapping(mapping = cleaned_mapping)]
+
+
+def _collect_maven_coordinate_impl(_target, ctx):
+    for file in _target.files:
+        if file.extension == 'jar':
+            jar_file = file.path
+
+    tags = getattr(ctx.rule.attr, "tags", [])
+    jar_coordinates = ""
+
+    for tag in tags:
+        if tag.startswith(MAVEN_COORDINATES_PREFIX):
+            jar_coordinates = tag[len(MAVEN_COORDINATES_PREFIX):]
+
+    return [JarToMavenCoordinatesMapping(
+        filename = jar_file,
+        maven_coordinates = jar_coordinates
+    )]
+
+
+_collect_maven_coordinate = aspect(
+    attr_aspects = [
+        "jars",
+        "deps",
+        "exports",
+        "runtime_deps"
+    ],
+    doc = """
+    Collects the Maven information for targets, their dependencies, and their transitive exports.
+    """,
+    implementation = _collect_maven_coordinate_impl,
+    provides = [JarToMavenCoordinatesMapping]
+)
+
+
+_transitive_collect_maven_coordinate = aspect(
+    attr_aspects = [
+        "jars",
+        "deps",
+        "exports",
+        "runtime_deps"
+    ],
+    required_aspect_providers = [JarToMavenCoordinatesMapping],
+    provides = [TransitiveJarToMavenCoordinatesMapping],
+    implementation = _transitive_collect_maven_coordinate_impl
+)
+
 
 def _java_deps_impl(ctx):
     names = {}
     files = []
     filenames = []
 
+    mapping = ctx.attr.target[TransitiveJarToMavenCoordinatesMapping].mapping
+
     for file in ctx.attr.target.data_runfiles.files.to_list():
         if file.basename in filenames:
             continue # do not pack JARs with same name
         if file.extension == 'jar' and not file.path.startswith(LOCAL_JDK_PREFIX):
-            names[file.path] = ctx.attr.java_deps_root + file.basename
+            filename = mapping.get(file.path, file.basename).replace('.', '-').replace(':', '-')
+            names[file.path] = ctx.attr.java_deps_root + filename + ".jar"
             files.append(file)
             filenames.append(file.basename)
 
@@ -24,8 +114,8 @@ def _java_deps_impl(ctx):
 
     ctx.actions.run(
         outputs = [ctx.outputs.distribution],
-        inputs = files + [jars_mapping],
-        arguments = [jars_mapping.path, ctx.outputs.distribution.path],
+        inputs = files + [jars_mapping, ctx.file.version_file],
+        arguments = [jars_mapping.path, ctx.outputs.distribution.path, ctx.file.version_file.path],
         executable = ctx.executable._java_deps_builder,
         progress_message = "Generating tarball with Java deps: {}".format(
             ctx.outputs.distribution.short_path)
@@ -34,9 +124,19 @@ def _java_deps_impl(ctx):
 
 java_deps = rule(
     attrs = {
-        "target": attr.label(mandatory=True),
+        "target": attr.label(
+            mandatory=True,
+            aspects = [
+                _collect_maven_coordinate,
+                _transitive_collect_maven_coordinate
+            ]
+        ),
         "java_deps_root": attr.string(
             doc = "Folder inside archive to put JARs into"
+        ),
+        "version_file": attr.label(
+            allow_single_file = True,
+            mandatory = True
         ),
         "_java_deps_builder": attr.label(
             default = "//common:java_deps",


### PR DESCRIPTION
## What is the goal of this PR?

Properly name JARs inside distributions

## What are the changes implemented in this PR?

* `_collect_maven_coordinate` aspect which associates `{file_name: maven_coordinate}` pair to each Java target
* `_transitive_collect_maven_coordinate` aspect which collects all of pairs associated by previous aspect and associated them to _one_ target we have access to in `java_deps` rule implementation
* `java_deps` now requires you give it `version_file` so it knows how to version artifacts with `{pom_version}` string