### PR TITLE
Support for multiple targets in deploy_github

### DIFF
--- a/github/rules.bzl
+++ b/github/rules.bzl
@@ -3,14 +3,30 @@ def _deploy_github_impl(ctx):
     ctx.actions.expand_template(
         template = ctx.file._deploy_script,
         output = _deploy_script,
-        substitutions = {}
+        substitutions = {
+            "{targets}": ",".join([file.short_path for file in ctx.files.targets + [ctx.file.target]]),
+            "{has_release_description}": str(int(bool(ctx.file.release_description)))
+        }
     )
+    files = [
+        ctx.file.target, ctx.file.deployment_properties,
+        ctx.file.version_file
+    ] + ctx.files._ghr + ctx.files.targets
+
+    symlinks = {
+        "deployment.properties": ctx.file.deployment_properties
+    }
+
+    if ctx.file.release_description:
+        files.append(ctx.file.release_description)
+        symlinks["release_description.txt"] = ctx.file.release_description
+
     return DefaultInfo(
         executable = _deploy_script,
-        runfiles = ctx.runfiles(files = [
-            ctx.file.target, ctx.file.deployment_properties,
-            ctx.file.version_file
-        ] + ctx.files._ghr)
+        runfiles = ctx.runfiles(
+            files = files,
+            symlinks = symlinks
+        ),
     )
 
 
@@ -19,7 +35,15 @@ deploy_github = rule(
         "target": attr.label(
             allow_single_file = [".zip"],
             mandatory = True,
-            doc = "`distribution_zip` label to be deployed",
+            doc = "`distribution_zip` label to be deployed. Deprecated: use 'targets' attribute instead",
+        ),
+        "targets": attr.label_list(
+            allow_files = [".zip", ".tar.gz"],
+            doc = "`assemble_zip` or `assemble_targz` label to be deployed",
+        ),
+        "release_description": attr.label(
+            allow_single_file = True,
+            doc = "Description of GitHub release"
         ),
         "deployment_properties": attr.label(
             allow_single_file = True,


### PR DESCRIPTION
## What is the goal of this PR?

Support GitHub deployment for multiple targets at once. Also, support optional release description.

## What are the changes implemented in this PR?

- New rule attribute: `targets`
- New rule attribute: `release_description`
- Symlink `deployment.properties` at execution root to actual file so it doesn't have to be hardcoded