### PR TITLE
Accept credentials from environment variable in deployment rules

### DIFF
--- a/apt/templates/deploy.sh
+++ b/apt/templates/deploy.sh
@@ -20,17 +20,23 @@
 
 set -e
 
-if [[ $# -ne 3 ]]; then
-    echo "Should pass <test> <deb-username> <deb-password> as arguments"
-    exit 1
-fi
 
-DEB_REPO_TYPE="$1"
-DEB_USERNAME="$2"
-DEB_PASSWORD="$3"
+DEB_REPO_TYPE="${1-${DEPLOYMENT_REPO_TYPE-notset}}"
+DEB_USERNAME="${2-${DEPLOYMENT_USERNAME-notset}}"
+DEB_PASSWORD="${3-${DEPLOYMENT_PASSWORD-notset}}"
 
 if [[ "$DEB_REPO_TYPE" != "test" ]]; then
     echo "Error: first argument should be 'test', not '$DEB_REPO_TYPE'"
+    exit 1
+fi
+
+if [[ "$DEB_USERNAME" == "notset" ]]; then
+    echo "Error: username should be either passed via cmdline or \$DEPLOYMENT_USERNAME env variable"
+    exit 1
+fi
+
+if [[ "$DEB_PASSWORD" == "notset" ]]; then
+    echo "Error: password should be either passed via cmdline or \$DEPLOYMENT_PASSWORD env variable"
     exit 1
 fi
 

--- a/pip/templates/deploy.sh
+++ b/pip/templates/deploy.sh
@@ -20,17 +20,22 @@
 
 set -e
 
-if [[ $# -ne 3 ]]; then
-    echo "Should pass <pypi|test|tpypi> <pip-username> <pip-password> as arguments"
-    exit 1
-fi
-
-PIP_REPO_TYPE="$1"
-PIP_USERNAME="$2"
-PIP_PASSWORD="$3"
+PIP_REPO_TYPE="${1-${DEPLOYMENT_REPO_TYPE-notset}}"
+PIP_USERNAME="${2-${DEPLOYMENT_USERNAME-notset}}"
+PIP_PASSWORD="${3-${DEPLOYMENT_PASSWORD-notset}}"
 
 if [[ "$PIP_REPO_TYPE" != "pypi" ]] && [[ "$PIP_REPO_TYPE" != "test" ]]; then
     echo "Error: first argument should be 'pypi' or 'test', not '$PIP_REPO_TYPE'"
+    exit 1
+fi
+
+if [[ "$PIP_USERNAME" == "notset" ]]; then
+    echo "Error: username should be either passed via cmdline or \$DEPLOYMENT_USERNAME env variable"
+    exit 1
+fi
+
+if [[ "$PIP_PASSWORD" == "notset" ]]; then
+    echo "Error: password should be either passed via cmdline or \$DEPLOYMENT_PASSWORD env variable"
     exit 1
 fi
 

--- a/rpm/templates/deploy.sh
+++ b/rpm/templates/deploy.sh
@@ -20,18 +20,24 @@
 
 set -e
 
-if [[ $# -ne 3 ]]; then
-    echo "Should pass <test> <rpm-username> <rpm-password> as arguments"
-    exit 1
-fi
 
 RPM_PKG="{RPM_PKG}"
-RPM_REPO_TYPE="$1"
-RPM_USERNAME="$2"
-RPM_PASSWORD="$3"
+RPM_REPO_TYPE="${1-${DEPLOYMENT_REPO_TYPE-notset}}"
+RPM_USERNAME="${2-${DEPLOYMENT_USERNAME-notset}}"
+RPM_PASSWORD="${3-${DEPLOYMENT_PASSWORD-notset}}"
 
 if [[ "$RPM_REPO_TYPE" != "test" ]]; then
     echo "Error: first argument should be 'test', not '$RPM_REPO_TYPE'"
+    exit 1
+fi
+
+if [[ "$RPM_USERNAME" == "notset" ]]; then
+    echo "Error: username should be either passed via cmdline or \$DEPLOYMENT_USERNAME env variable"
+    exit 1
+fi
+
+if [[ "$RPM_PASSWORD" == "notset" ]]; then
+    echo "Error: password should be either passed via cmdline or \$DEPLOYMENT_PASSWORD env variable"
     exit 1
 fi
 


### PR DESCRIPTION
## What is the goal of this PR?

`deploy_(apt|rpm|npm|pip)` rules now accept credentials via environment variables: `$DEPLOYMENT_REPO_TYPE`, `$DEPLOYMENT_USERNAME`, `$DEPLOYMENT_PASSWORD`, `$DEPLOYMENT_EMAIL` [for `npm`]

This is done so we're able to not expose our credentials (`bazel` prints out command being executed and the behaviour is non-configurable)

## What are the changes implemented in this PR?

- Remove `$#` check for number of arguments
- If command line argument was not passed, default to environment variable (see above); if it's also not present, default to `notset`, see [this guide](https://unix.stackexchange.com/a/62337)
- Check that credential is not set to "notset`; exit with error if it is
