### PR TITLE
Make 'target' attribute non-mandatory for deploy_github

### DIFF
--- a/github/rules.bzl
+++ b/github/rules.bzl
@@ -34,7 +34,6 @@ deploy_github = rule(
     attrs = {
         "target": attr.label(
             allow_single_file = [".zip"],
-            mandatory = True,
             doc = "`distribution_zip` label to be deployed. Deprecated: use 'targets' attribute instead",
         ),
         "targets": attr.label_list(


### PR DESCRIPTION
## What is the goal of this PR?

`deploy_github` should not enforce taking single `target` as argument

## What are the changes implemented in this PR?

- Removed `mandatory=True` on `deploy_github` rule definition