### PR TITLE
Bugfix deploy_github rule

### DIFF
--- a/github/rules.bzl
+++ b/github/rules.bzl
@@ -1,17 +1,23 @@
 def _deploy_github_impl(ctx):
     _deploy_script = ctx.actions.declare_file("_deploy.py")
+
+    files_to_deploy = []
+    files_to_deploy.extend(ctx.files.targets)
+    if ctx.file.target:
+        files_to_deploy.append(ctx.file.target)
+
     ctx.actions.expand_template(
         template = ctx.file._deploy_script,
         output = _deploy_script,
         substitutions = {
-            "{targets}": ",".join([file.short_path for file in ctx.files.targets + [ctx.file.target]]),
+            "{targets}": ",".join([file.short_path for file in files_to_deploy]),
             "{has_release_description}": str(int(bool(ctx.file.release_description)))
         }
     )
     files = [
-        ctx.file.target, ctx.file.deployment_properties,
+        ctx.file.deployment_properties,
         ctx.file.version_file
-    ] + ctx.files._ghr + ctx.files.targets
+    ] + ctx.files._ghr + files_to_deploy
 
     symlinks = {
         "deployment.properties": ctx.file.deployment_properties


### PR DESCRIPTION
## What is the goal of this PR?

Fix `deploy_github` rule so it works when you don't specify single target

## What are the changes implemented in this PR?

Add a condition to not add `ctx.file.target` it it's not set