### PR TITLE
assemble_maven uses the commit id of git_repository dependencies when writing pom.xml

### DIFF
--- a/maven/BUILD
+++ b/maven/BUILD
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-exports_files(["deployment_rules_builder.py"])
+exports_files(["deployment_rules_builder.py", "_pom_replace_version.py"])
 
 py_binary(
     name = "assemble",

--- a/maven/_pom_replace_version.py
+++ b/maven/_pom_replace_version.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python
+
+import json
+import sys
+
+_, preprocessed_template_path, workspace_refs_path, version_file_path, pom_path = sys.argv
+
+with open(preprocessed_template_path, 'r') as template_file, \
+        open(workspace_refs_path, 'r') as refs_file, \
+        open(version_file_path, 'r') as version_file, \
+        open(pom_path, 'w') as pom_file:
+
+    refs = json.loads(refs_file.read().strip())
+    template = template_file.read().strip()
+    version = version_file.read().strip()
+
+    pom = template
+    for workspace in refs['commits']:
+        pom = pom.replace(workspace, refs['commits'][workspace])
+    for workspace in refs['tags']:
+        pom = pom.replace(workspace, refs['tags'][workspace])
+    pom = pom.replace('{pom_version}', version)
+
+    pom_file.write(pom)

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -73,7 +73,7 @@ if maven_repo_type not in valid_keys:
 maven_url = properties[MAVEN_REPO_KEY_PREFIX + maven_repo_type]
 
 filename_base = '{coordinates}/{artifact}/{version}/{artifact}-{version}'.format(
-    coordinates=group_id, version=version, artifact=artifact_id)
+    coordinates=group_id.replace('.', '/'), version=version, artifact=artifact_id)
 
 upload(maven_url, maven_username, maven_password, jar_path, filename_base + '.jar')
 upload(maven_url, maven_username, maven_password, pom_file_path, filename_base + '.pom')


### PR DESCRIPTION
## What is the goal of this PR?
`assemble_maven` can now use information about dependencies that is declared using `git_repository` for when generating `pom.xml`
