### PR TITLE
Allow deploy_github rule to deploy releases with no files

### DIFF
--- a/github/deploy.py
+++ b/github/deploy.py
@@ -41,7 +41,7 @@ def parse_deployment_properties(fn):
     return deployment_properties
 
 
-targets = "{targets}".split(',')
+targets = list(filter(None, "{targets}".split(',')))
 has_release_description = bool(int("{has_release_description}"))
 
 properties = parse_deployment_properties('deployment.properties')
@@ -71,6 +71,13 @@ else:
     sys.exit(1)
 
 directory_to_upload = tempfile.mkdtemp()
+
+# TODO: ideally, this should be fixed in ghr itself
+# Currently it does not allow supplying empty folders
+# However, it also filters out folders inside the folder you supply
+# So if we have a folder within a folder, both conditions are
+# satisfied and we're able to proceed
+dummy_directory = tempfile.mkdtemp(dir=directory_to_upload)
 for fl in targets:
     shutil.copy(fl, os.path.join(directory_to_upload, os.path.basename(fl)))
 

--- a/github/deploy.py
+++ b/github/deploy.py
@@ -41,7 +41,7 @@ def parse_deployment_properties(fn):
     return deployment_properties
 
 
-targets = list(filter(None, "{targets}".split(',')))
+targets = [] if not "{targets}" else "{targets}".split(',')
 has_release_description = bool(int("{has_release_description}"))
 
 properties = parse_deployment_properties('deployment.properties')


### PR DESCRIPTION
## What is the goal of this PR?

[graknlabs/client-python](https://github.com/graknlabs/client-python), [graknlabs/client-nodejs](https://github.com/graknlabs/client-nodejs), [graknlabs/graql](https://github.com/graknlabs/graql) all require GitHub releases with no files (actual artifacts are deployed to PyPI, NPM and Maven, respectively)

## What are the changes implemented in this PR?

- Add a filtering statement so that we have `[]` (empty list) instead of `['']` (a list with an empty string)
- Create a dummy directory inside directory without artifacts to allow `ghr` to proceed uploading 
