### PR TITLE
deploy-maven: fix an issue with supplying custom deployment.properties

### DIFF
--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -68,7 +68,7 @@ if repo_type == 'release' and len(re.findall(version_release_regex, version)) ==
                      'must have a version which complies to this regex: {}'
                      .format(version, repo_type, version_snapshot_regex))
 
-deployment_properties = parse_deployment_properties('external/graknlabs_build_tools/deployment.properties')
+deployment_properties = parse_deployment_properties('deployment.properties')
 maven_url = deployment_properties['repo.maven.' + repo_type]
 jar_path = "$JAR_PATH"
 pom_file_path = "$POM_PATH"

--- a/maven/templates/rules.bzl
+++ b/maven/templates/rules.bzl
@@ -274,6 +274,7 @@ def _deploy_maven_impl(ctx):
         ], symlinks = {
             lib_jar_link: ctx.attr.target[MavenDeploymentInfo].jar,
             pom_xml_link: ctx.attr.target[MavenDeploymentInfo].pom,
+            'deployment.properties': ctx.file.deployment_properties,
         })
     )
 


### PR DESCRIPTION
## What is the goal of this PR?

If you supply a custom `deployment_properties`, the command will fail:
```
# BUILD file
deploy_maven(
    name = "deploy-maven",
    target = ":assemble-maven",
    deployment_properties = "//a/custom:deployment.properties"
)

bazel run //java:deploy-maven -- release (cat VERSION) $user $pass
...
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_lolski/f1893223ba4c11af3d06827cbf1a1b3f/execroot/graknlabs_graql/bazel-out/darwin-fastbuild/bin/java/deploy.py", line 71, in <module>
    deployment_properties = parse_deployment_properties('external/graknlabs_build_tools/deployment.properties')
  File "/private/var/tmp/_bazel_lolski/f1893223ba4c11af3d06827cbf1a1b3f/execroot/graknlabs_graql/bazel-out/darwin-fastbuild/bin/java/deploy.py", line 19, in parse_deployment_properties
    with open(fn) as deployment_properties_file:
IOError: [Errno 2] No such file or directory: 'external/graknlabs_build_tools/deployment.properties'
```

This PR fixes the issue.