### PR TITLE
Support Caskroom deployments for deploy_brew

### DIFF
--- a/brew/rules.bzl
+++ b/brew/rules.bzl
@@ -1,8 +1,15 @@
 def _deploy_brew_impl(ctx):
+    if ctx.attr.type == "brew":
+        brew_formula_folder = "Formula"
+    elif ctx.attr.type == "cask":
+        brew_formula_folder = "Casks"
+
     ctx.actions.expand_template(
         template = ctx.file._deploy_brew_template,
         output = ctx.outputs.deployment_script,
-        substitutions = {},
+        substitutions = {
+            "{brew_folder}": brew_formula_folder
+        },
         is_executable = True
     )
     return DefaultInfo(
@@ -33,6 +40,10 @@ deploy_brew = rule(
         "checksum": attr.label(
             allow_single_file = True,
             mandatory = True,
+        ),
+        "type": attr.string(
+            values = ["brew", "cask"],
+            default = "brew"
         ),
         "deployment_properties": attr.label(
             allow_single_file = True,

--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -59,7 +59,7 @@ tap_localpath = tempfile.mkdtemp()
 try:
     print('Cloning brew tap: "{}"...'.format(tap_url))
     sp.check_call(['git', 'clone', tap_url, tap_localpath])
-    sp.check_call(['mkdir', '-p', 'Formula'], cwd=tap_localpath)
+    sp.check_call(['mkdir', '-p', '{brew_folder}'], cwd=tap_localpath)
     formula_content = formula_template.replace('{version}', version).replace('{sha256}', checksum_of_distribution_local)
     distribution_url = get_distribution_url_from_formula(formula_content)
     print('Attempting to match the checksums of local distribution and Github distribution from "{}"...'.format(distribution_url))
@@ -71,7 +71,7 @@ try:
         print('- The checksum of Github distribution: {}'.format(checksum_of_distribution_github))
         sys.exit(1)
     print('The checksums matched. Proceeding with deploying to brew...')
-    with open(os.path.join(tap_localpath, 'Formula', formula_filename), 'w') as f:
+    with open(os.path.join(tap_localpath, '{brew_folder}', formula_filename), 'w') as f:
         f.write(formula_content)
     sp.check_call(['git', 'add', '.'], cwd=tap_localpath)
     try:


### PR DESCRIPTION
## What is the goal of this PR?

Workbase, being a graphical app, requires a _cask_ instead of a brew formula. Thankfully, we can use the same tap ([graknlabs/homebrew-tap](https://github.com/graknlabs/homebrew-tap)), but folder layout is a little bit different.

## What are the changes implemented in this PR?

Modify folder in which formula is created (`Formula`/`Casks` based on formula type)