### PR TITLE
Allow getting sha256 checksum from env variable instead of bazel target

### DIFF
--- a/brew/rules.bzl
+++ b/brew/rules.bzl
@@ -12,20 +12,26 @@ def _deploy_brew_impl(ctx):
         },
         is_executable = True
     )
+    files = [
+        ctx.file.deployment_properties,
+        ctx.file.formula,
+        ctx.file.version_file
+    ]
+
+    symlinks = {
+        'deployment.properties': ctx.file.deployment_properties,
+        'formula': ctx.file.formula,
+        'VERSION': ctx.file.version_file
+    }
+
+    if ctx.file.checksum:
+        files.append(ctx.file.checksum)
+        symlinks['checksum.sha256'] = ctx.file.checksum
+
     return DefaultInfo(
         runfiles = ctx.runfiles(
-            files = [
-                ctx.file.checksum,
-                ctx.file.deployment_properties,
-                ctx.file.formula,
-                ctx.file.version_file
-            ],
-            symlinks = {
-                'checksum.sha256': ctx.file.checksum,
-                'deployment.properties': ctx.file.deployment_properties,
-                'formula': ctx.file.formula,
-                'VERSION': ctx.file.version_file
-            }
+            files = files,
+            symlinks = symlinks
         ),
         executable = ctx.outputs.deployment_script
     )
@@ -39,7 +45,6 @@ deploy_brew = rule(
         ),
         "checksum": attr.label(
             allow_single_file = True,
-            mandatory = True,
         ),
         "type": attr.string(
             values = ["brew", "cask"],

--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -33,6 +33,18 @@ def url_with_credential(url, credential):
     return scheme + '://"' + credential + '"@' + rest
 
 
+def get_checksum():
+    if os.path.isfile('checksum.sha256'):
+        with open('checksum.sha256') as checksum_file:
+            return checksum_file.read().strip().split(' ')[0]
+    elif 'DEPLOY_BREW_CHECKSUM' in os.environ:
+        return os.getenv('DEPLOY_BREW_CHECKSUM')
+    else:
+        raise ValueError('Error - checksum should either be defined '
+                         'in checksum.sha256 file or '
+                         '$DEPLOY_BREW_CHECKSUM env variable')
+
+
 if not os.getenv('GRABL_CREDENTIAL'):
     print('Error - $GRABL_CREDENTIAL must be defined')
     sys.exit(1)
@@ -52,8 +64,8 @@ with open('VERSION') as version_file:
     version = version_file.read().strip()
 tap_type = sys.argv[1]
 tap_url = properties['repo.brew.{}'.format(tap_type)]
-with open('checksum.sha256') as checksum_file:
-    checksum_of_distribution_local = checksum_file.read().strip().split(' ')[0]
+
+checksum_of_distribution_local = get_checksum()
 
 tap_localpath = tempfile.mkdtemp()
 try:


### PR DESCRIPTION
## What is the goal of this PR?

Workbase builds are done outside of `bazel`, which would not allow us to pass `checksum` to `bazel` target

## What are the changes implemented in this PR?

- Make `checksum` attribute non-mandatory in `deploy_brew`
- Refactor getting checksum logic into a separate function which either reads a file, reads an env variable or throws an error.