### PR TITLE
apt and rpm rules should accept release repository

### DIFF
--- a/apt/templates/deploy.sh
+++ b/apt/templates/deploy.sh
@@ -25,8 +25,8 @@ DEB_REPO_TYPE="${1-${DEPLOYMENT_REPO_TYPE-notset}}"
 DEB_USERNAME="${2-${DEPLOYMENT_USERNAME-notset}}"
 DEB_PASSWORD="${3-${DEPLOYMENT_PASSWORD-notset}}"
 
-if [[ "$DEB_REPO_TYPE" != "test" ]]; then
-    echo "Error: first argument should be 'test', not '$DEB_REPO_TYPE'"
+if [[ "$DEB_REPO_TYPE" != "test" ]] && [[ "$DEB_REPO_TYPE" != "release" ]]; then
+    echo "Error: first argument should be 'test' or 'release', not '$DEB_REPO_TYPE'"
     exit 1
 fi
 

--- a/rpm/templates/deploy.sh
+++ b/rpm/templates/deploy.sh
@@ -26,8 +26,8 @@ RPM_REPO_TYPE="${1-${DEPLOYMENT_REPO_TYPE-notset}}"
 RPM_USERNAME="${2-${DEPLOYMENT_USERNAME-notset}}"
 RPM_PASSWORD="${3-${DEPLOYMENT_PASSWORD-notset}}"
 
-if [[ "$RPM_REPO_TYPE" != "test" ]]; then
-    echo "Error: first argument should be 'test', not '$RPM_REPO_TYPE'"
+if [[ "$RPM_REPO_TYPE" != "test" ]] && [[ "$RPM_REPO_TYPE" != "release" ]]; then
+    echo "Error: first argument should be 'test' or 'release', not '$RPM_REPO_TYPE'"
     exit 1
 fi
 


### PR DESCRIPTION
## What is the goal of this PR?

Currently, `deploy_apt` and `deploy_rpm` rules only accepts `test` repository.

This PR updates them so they accept `release` repository in addition to `test`:
```
DEPLOYMENT_REPO_TYPE=release DEPLOYMENT_USERNAME=... DEPLOYMENT_PASSWORD=... bazel run //bin:deploy-apt
```