### PR TITLE
deploy_github - uploaded distribution should contain version numbers

### DIFF
--- a/github/deploy.py
+++ b/github/deploy.py
@@ -91,8 +91,15 @@ directory_to_upload = tempfile.mkdtemp()
 dummy_directory = tempfile.mkdtemp(dir=directory_to_upload)
 
 for fl in targets:
-    filename, extension = os.path.splitext(fl)
-    final_name = '{}-{}{}'.format(filename, distribution_version, extension)
+    if fl.endswith('zip'):
+        extension = 'zip'
+    elif fl.endswith('tar.gz'):
+        extension = 'tar.gz'
+    else:
+        raise ValueError('This file is neither a zip nor a tar.gz: {}'.format(fl))
+
+    filename = fl[:-len(extension)-1]
+    final_name = os.path.basename('{}-{}.{}'.format(filename, distribution_version, extension))
     shutil.copy(fl, os.path.join(directory_to_upload, final_name))
 
 try:

--- a/github/deploy.py
+++ b/github/deploy.py
@@ -89,8 +89,11 @@ directory_to_upload = tempfile.mkdtemp()
 # So if we have a folder within a folder, both conditions are
 # satisfied and we're able to proceed
 dummy_directory = tempfile.mkdtemp(dir=directory_to_upload)
+
 for fl in targets:
-    shutil.copy(fl, os.path.join(directory_to_upload, os.path.basename(fl)))
+    filename, extension = os.path.splitext(fl)
+    final_name = '{}-{}{}'.format(filename, distribution_version, extension)
+    shutil.copy(fl, os.path.join(directory_to_upload, final_name))
 
 try:
     subprocess.call([


### PR DESCRIPTION
## What is the goal of this PR?

Add version to the filename of distributions that are uploaded to GitHub:

- grakn-core-server-windows-1.5.0.zip
- grakn-core-console-mac-1.5.0.zip
- grakn-core-server-1.5.0.tar.gz
- grakn-core-console-1.5.0.tar.gz
- grakn-core-all-mac-1.5.0.zip
- grakn-core-all-windows-1.5.0.zip
- grakn-core-console-windows-1.5.0.zip
- grakn-core-all-linux-1.5.0.tar.gz
- grakn-core-server-mac-1.5.0.zip