### PR TITLE
Assemble apt modifications

### DIFF
--- a/apt/pkg_deb_modified_from_bazel/BUILD
+++ b/apt/pkg_deb_modified_from_bazel/BUILD
@@ -1,0 +1,35 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+py_library(
+    name = "archive",
+    srcs = ["archive.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+)
+
+py_binary(
+    name = "make_deb",
+    srcs = ["make_deb.py"],
+    srcs_version = "PY2AND3",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":archive",
+        "@bazel_tools//third_party/py/gflags",
+    ],
+)

--- a/apt/pkg_deb_modified_from_bazel/archive.py
+++ b/apt/pkg_deb_modified_from_bazel/archive.py
@@ -1,0 +1,443 @@
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Archive manipulation library for the Docker rules."""
+
+# pylint: disable=g-import-not-at-top
+import gzip
+import io
+import os
+import subprocess
+import tarfile
+
+# Use a deterministic mtime that doesn't confuse other programs.
+# See: https://github.com/bazelbuild/bazel/issues/1299
+PORTABLE_MTIME = 946684800  # 2000-01-01 00:00:00.000 UTC
+
+
+class SimpleArFile(object):
+    """A simple AR file reader.
+
+    This enable to read AR file (System V variant) as described
+    in https://en.wikipedia.org/wiki/Ar_(Unix).
+
+    The standard usage of this class is:
+
+    with SimpleArFile(filename) as ar:
+      nextFile = ar.next()
+      while nextFile:
+        print(nextFile.filename)
+        nextFile = ar.next()
+
+    Upon error, this class will raise a ArError exception.
+    """
+
+    # TODO(dmarting): We should use a standard library instead but python 2.7
+    #   does not have AR reading library.
+
+    class ArError(Exception):
+        pass
+
+    class SimpleArFileEntry(object):
+        """Represent one entry in a AR archive.
+
+        Attributes:
+          filename: the filename of the entry, as described in the archive.
+          timestamp: the timestamp of the file entry.
+          owner_id, group_id: numeric id of the user and group owning the file.
+          mode: unix permission mode of the file
+          size: size of the file
+          data: the content of the file.
+        """
+
+        def __init__(self, f):
+            self.filename = f.read(16).decode('utf-8').strip()
+            if self.filename.endswith('/'):  # SysV variant
+                self.filename = self.filename[:-1]
+            self.timestamp = int(f.read(12).strip())
+            self.owner_id = int(f.read(6).strip())
+            self.group_id = int(f.read(6).strip())
+            self.mode = int(f.read(8).strip(), 8)
+            self.size = int(f.read(10).strip())
+            pad = f.read(2)
+            if pad != b'\x60\x0a':
+                raise SimpleArFile.ArError('Invalid AR file header')
+            self.data = f.read(self.size)
+
+    MAGIC_STRING = b'!<arch>\n'
+
+    def __init__(self, filename):
+        self.filename = filename
+
+    def __enter__(self):
+        self.f = open(self.filename, 'rb')
+        if self.f.read(len(self.MAGIC_STRING)) != self.MAGIC_STRING:
+            raise self.ArError('Not a ar file: ' + self.filename)
+        return self
+
+    def __exit__(self, t, v, traceback):
+        self.f.close()
+
+    def next(self):
+        """Read the next file. Returns None when reaching the end of file."""
+        # AR sections are two bit aligned using new lines.
+        if self.f.tell() % 2 != 0:
+            self.f.read(1)
+        # An AR sections is at least 60 bytes. Some file might contains garbage
+        # bytes at the end of the archive, ignore them.
+        if self.f.tell() > os.fstat(self.f.fileno()).st_size - 60:
+            return None
+        return self.SimpleArFileEntry(self.f)
+
+
+class TarFileWriter(object):
+    """A wrapper to write tar files."""
+
+    class Error(Exception):
+        pass
+
+    def __init__(self,
+                 name,
+                 compression='',
+                 root_directory='./',
+                 default_mtime=None):
+        """TarFileWriter wraps tarfile.open().
+
+        Args:
+          name: the tar file name.
+          compression: compression type: bzip2, bz2, gz, tgz, xz, lzma.
+          root_directory: virtual root to prepend to elements in the archive.
+          default_mtime: default mtime to use for elements in the archive.
+              May be an integer or the value 'portable' to use the date
+              2000-01-01, which is compatible with non *nix OSes'.
+        """
+        if compression in ['bzip2', 'bz2']:
+            mode = 'w:bz2'
+        else:
+            mode = 'w:'
+        self.gz = compression in ['tgz', 'gz']
+        # Support xz compression through xz... until we can use Py3
+        self.xz = compression in ['xz', 'lzma']
+        self.name = name
+        self.root_directory = root_directory.rstrip('/')
+        if default_mtime is None:
+            self.default_mtime = 0
+        elif default_mtime == 'portable':
+            self.default_mtime = PORTABLE_MTIME
+        else:
+            self.default_mtime = int(default_mtime)
+
+        self.fileobj = None
+        if self.gz:
+            # The Tarfile class doesn't allow us to specify gzip's mtime attribute.
+            # Instead, we manually re-implement gzopen from tarfile.py and set mtime.
+            self.fileobj = gzip.GzipFile(
+                filename=name, mode='w', compresslevel=9, mtime=self.default_mtime)
+        self.tar = tarfile.open(name=name, mode=mode, fileobj=self.fileobj)
+        self.members = set([])
+        self.directories = set([])
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, t, v, traceback):
+        self.close()
+
+    def add_dir(self,
+                name,
+                path,
+                uid=0,
+                gid=0,
+                uname='',
+                gname='',
+                mtime=None,
+                mode=None,
+                depth=100):
+        """Recursively add a directory.
+
+        Args:
+          name: the destination path of the directory to add.
+          path: the path of the directory to add.
+          uid: owner user identifier.
+          gid: owner group identifier.
+          uname: owner user names.
+          gname: owner group names.
+          mtime: modification time to put in the archive.
+          mode: unix permission mode of the file, default 0644 (0755).
+          depth: maximum depth to recurse in to avoid infinite loops
+                 with cyclic mounts.
+
+        Raises:
+          TarFileWriter.Error: when the recursion depth has exceeded the
+                               `depth` argument.
+        """
+        if not (name == self.root_directory or name.startswith('/') or
+                name.startswith(self.root_directory + '/')):
+            name = os.path.join(self.root_directory, name)
+        if mtime is None:
+            mtime = self.default_mtime
+        if os.path.isdir(path):
+            # Remove trailing '/' (index -1 => last character)
+            if name[-1] == '/':
+                name = name[:-1]
+            # Add the x bit to directories to prevent non-traversable directories.
+            # The x bit is set only to if the read bit is set.
+            dirmode = (mode | ((0o444 & mode) >> 2)) if mode else mode
+            self.add_file(name + '/',
+                          tarfile.DIRTYPE,
+                          uid=uid,
+                          gid=gid,
+                          uname=uname,
+                          gname=gname,
+                          mtime=mtime,
+                          mode=dirmode)
+            if depth <= 0:
+                raise self.Error('Recursion depth exceeded, probably in '
+                                 'an infinite directory loop.')
+            # Iterate over the sorted list of file so we get a deterministic result.
+            filelist = os.listdir(path)
+            filelist.sort()
+            for f in filelist:
+                new_name = os.path.join(name, f)
+                new_path = os.path.join(path, f)
+                self.add_dir(new_name, new_path, uid, gid, uname, gname, mtime, mode,
+                             depth - 1)
+        else:
+            self.add_file(name,
+                          tarfile.REGTYPE,
+                          file_content=path,
+                          uid=uid,
+                          gid=gid,
+                          uname=uname,
+                          gname=gname,
+                          mtime=mtime,
+                          mode=mode)
+
+    def _addfile(self, info, fileobj=None):
+        """Add a file in the tar file if there is no conflict."""
+        if not info.name.endswith('/') and info.type == tarfile.DIRTYPE:
+            # Enforce the ending / for directories so we correctly deduplicate.
+            info.name += '/'
+        if info.name not in self.members:
+            self.tar.addfile(info, fileobj)
+            self.members.add(info.name)
+        elif info.type != tarfile.DIRTYPE:
+            print('Duplicate file in archive: %s, '
+                  'picking first occurrence' % info.name)
+
+    def add_file(self,
+                 name,
+                 kind=tarfile.REGTYPE,
+                 content=None,
+                 link=None,
+                 file_content=None,
+                 uid=0,
+                 gid=0,
+                 uname='',
+                 gname='',
+                 mtime=None,
+                 mode=None):
+        """Add a file to the current tar.
+
+        Args:
+          name: the name of the file to add.
+          kind: the type of the file to add, see tarfile.*TYPE.
+          content: a textual content to put in the file.
+          link: if the file is a link, the destination of the link.
+          file_content: file to read the content from. Provide either this
+              one or `content` to specifies a content for the file.
+          uid: owner user identifier.
+          gid: owner group identifier.
+          uname: owner user names.
+          gname: owner group names.
+          mtime: modification time to put in the archive.
+          mode: unix permission mode of the file, default 0644 (0755).
+        """
+        if file_content and os.path.isdir(file_content):
+            # Recurse into directory
+            self.add_dir(name, file_content, uid, gid, uname, gname, mtime, mode)
+            return
+        if not (name == self.root_directory or name.startswith('/') or
+                name.startswith(self.root_directory + '/')):
+            name = os.path.join(self.root_directory, name)
+        if kind == tarfile.DIRTYPE:
+            name = name.rstrip('/')
+            if name in self.directories:
+                return
+        if mtime is None:
+            mtime = self.default_mtime
+
+        components = name.rsplit('/', 1)
+        if len(components) > 1:
+            d = components[0]
+            self.add_file(d,
+                          tarfile.DIRTYPE,
+                          uid=uid,
+                          gid=gid,
+                          uname=uname,
+                          gname=gname,
+                          mtime=mtime,
+                          mode=0o755)
+        tarinfo = tarfile.TarInfo(name)
+        tarinfo.mtime = mtime
+        tarinfo.uid = uid
+        tarinfo.gid = gid
+        tarinfo.uname = uname
+        tarinfo.gname = gname
+        tarinfo.type = kind
+        if mode is None:
+            tarinfo.mode = 0o644 if kind == tarfile.REGTYPE else 0o755
+        else:
+            tarinfo.mode = mode
+        if link:
+            tarinfo.linkname = link
+        if content:
+            content_bytes = content.encode('utf-8')
+            tarinfo.size = len(content_bytes)
+            self._addfile(tarinfo, io.BytesIO(content_bytes))
+        elif file_content:
+            with open(file_content, 'rb') as f:
+                tarinfo.size = os.fstat(f.fileno()).st_size
+                self._addfile(tarinfo, f)
+        else:
+            if kind == tarfile.DIRTYPE:
+                self.directories.add(name)
+            self._addfile(tarinfo)
+
+    def add_tar(self,
+                tar,
+                rootuid=None,
+                rootgid=None,
+                numeric=False,
+                name_filter=None,
+                root=None):
+        """Merge a tar content into the current tar, stripping timestamp.
+
+        Args:
+          tar: the name of tar to extract and put content into the current tar.
+          rootuid: user id that we will pretend is root (replaced by uid 0).
+          rootgid: group id that we will pretend is root (replaced by gid 0).
+          numeric: set to true to strip out name of owners (and just use the
+              numeric values).
+          name_filter: filter out file by names. If not none, this method will be
+              called for each file to add, given the name and should return true if
+              the file is to be added to the final tar and false otherwise.
+          root: place all non-absolute content under given root directory, if not
+              None.
+
+        Raises:
+          TarFileWriter.Error: if an error happens when uncompressing the tar file.
+        """
+        if root and root[0] not in ['/', '.']:
+            # Root prefix should start with a '/', adds it if missing
+            root = '/' + root
+        compression = os.path.splitext(tar)[-1][1:]
+        if compression == 'tgz':
+            compression = 'gz'
+        elif compression == 'bzip2':
+            compression = 'bz2'
+        elif compression == 'lzma':
+            compression = 'xz'
+        elif compression not in ['gz', 'bz2', 'xz']:
+            compression = ''
+        if compression == 'xz':
+            # Python 2 does not support lzma, our py3 support is terrible so let's
+            # just hack around.
+            # Note that we buffer the file in memory and it can have an important
+            # memory footprint but it's probably fine as we don't use them for really
+            # large files.
+            # TODO(dmarting): once our py3 support gets better, compile this tools
+            # with py3 for proper lzma support.
+            if subprocess.call('which xzcat', shell=True, stdout=subprocess.PIPE):
+                raise self.Error('Cannot handle .xz and .lzma compression: '
+                                 'xzcat not found.')
+            p = subprocess.Popen('cat %s | xzcat' % tar,
+                                 shell=True,
+                                 stdout=subprocess.PIPE)
+            f = io.BytesIO(p.stdout.read())
+            p.wait()
+            intar = tarfile.open(fileobj=f, mode='r:')
+        else:
+            if compression in ['gz', 'bz2']:
+                # prevent performance issues due to accidentally-introduced seeks
+                # during intar traversal by opening in "streaming" mode. gz, bz2
+                # are supported natively by python 2.7 and 3.x
+                inmode = 'r|' + compression
+            else:
+                inmode = 'r:' + compression
+            intar = tarfile.open(name=tar, mode=inmode)
+        for tarinfo in intar:
+            if name_filter is None or name_filter(tarinfo.name):
+                tarinfo.mtime = self.default_mtime
+                if rootuid is not None and tarinfo.uid == rootuid:
+                    tarinfo.uid = 0
+                    tarinfo.uname = 'root'
+                if rootgid is not None and tarinfo.gid == rootgid:
+                    tarinfo.gid = 0
+                    tarinfo.gname = 'root'
+                if numeric:
+                    tarinfo.uname = ''
+                    tarinfo.gname = ''
+
+                name = tarinfo.name
+                if (not name.startswith('/') and
+                        not name.startswith(self.root_directory)):
+                    name = os.path.join(self.root_directory, name)
+                if root is not None:
+                    if name.startswith('.'):
+                        name = '.' + root + name.lstrip('.')
+                        # Add root dir with same permissions if missing. Note that
+                        # add_file deduplicates directories and is safe to call here.
+                        self.add_file('.' + root,
+                                      tarfile.DIRTYPE,
+                                      uid=tarinfo.uid,
+                                      gid=tarinfo.gid,
+                                      uname=tarinfo.uname,
+                                      gname=tarinfo.gname,
+                                      mtime=tarinfo.mtime,
+                                      mode=0o755)
+                    # Relocate internal hardlinks as well to avoid breaking them.
+                    link = tarinfo.linkname
+                    if link.startswith('.') and tarinfo.type == tarfile.LNKTYPE:
+                        tarinfo.linkname = '.' + root + link.lstrip('.')
+                tarinfo.name = name
+
+                if tarinfo.isfile():
+                    # use extractfile(tarinfo) instead of tarinfo.name to preserve
+                    # seek position in intar
+                    self._addfile(tarinfo, intar.extractfile(tarinfo))
+                else:
+                    self._addfile(tarinfo)
+        intar.close()
+
+    def close(self):
+        """Close the output tar file.
+
+        This class should not be used anymore after calling that method.
+
+        Raises:
+          TarFileWriter.Error: if an error happens when compressing the output file.
+        """
+        self.tar.close()
+        # Close the gzip file object if necessary.
+        if self.fileobj:
+            self.fileobj.close()
+        if self.xz:
+            # Support xz compression through xz... until we can use Py3
+            if subprocess.call('which xz', shell=True, stdout=subprocess.PIPE):
+                raise self.Error('Cannot handle .xz and .lzma compression: '
+                                 'xz not found.')
+            subprocess.call(
+                'mv {0} {0}.d && xz -z {0}.d && mv {0}.d.xz {0}'.format(self.name),
+                shell=True,
+                stdout=subprocess.PIPE)

--- a/apt/pkg_deb_modified_from_bazel/make_deb.py
+++ b/apt/pkg_deb_modified_from_bazel/make_deb.py
@@ -1,0 +1,355 @@
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""A simple cross-platform helper to create a debian package."""
+
+import gzip
+import hashlib
+from io import BytesIO
+import os
+import os.path
+import sys
+import tarfile
+import textwrap
+import time
+
+from third_party.py import gflags
+
+# list of debian fields : (name, mandatory, wrap[, default])
+# see http://www.debian.org/doc/debian-policy/ch-controlfields.html
+DEBIAN_FIELDS = [
+    ('Package', True, False),
+    ('Version', True, False),
+    ('Section', False, False, 'contrib/devel'),
+    ('Priority', False, False, 'optional'),
+    ('Architecture', False, False, 'all'),
+    ('Depends', False, True, []),
+    ('Recommends', False, True, []),
+    ('Suggests', False, True, []),
+    ('Enhances', False, True, []),
+    ('Conflicts', False, True, []),
+    ('Pre-Depends', False, True, []),
+    ('Installed-Size', False, False),
+    ('Maintainer', True, False),
+    ('Description', True, True),
+    ('Homepage', False, False),
+    ('Built-Using', False, False, 'Bazel'),
+    ('Distribution', False, False, 'unstable'),
+    ('Urgency', False, False, 'medium'),
+]
+
+gflags.DEFINE_string('output', None, 'The output file, mandatory')
+gflags.MarkFlagAsRequired('output')
+
+gflags.DEFINE_string('changes', None, 'The changes output file, mandatory.')
+gflags.MarkFlagAsRequired('changes')
+
+gflags.DEFINE_string('data', None,
+                     'Path to the data tarball, mandatory')
+gflags.MarkFlagAsRequired('data')
+
+gflags.DEFINE_string('preinst', None,
+                     'The preinst script (prefix with @ to provide a path).')
+gflags.DEFINE_string('postinst', None,
+                     'The postinst script (prefix with @ to provide a path).')
+gflags.DEFINE_string('prerm', None,
+                     'The prerm script (prefix with @ to provide a path).')
+gflags.DEFINE_string('postrm', None,
+                     'The postrm script (prefix with @ to provide a path).')
+
+# size of chunks for copying package content to final .deb file
+# This is a wild guess, but I am not convinced of the value of doing much work
+# to tune it.
+_COPY_CHUNK_SIZE = 1024 * 32
+
+# see
+# https://www.debian.org/doc/manuals/debian-faq/ch-pkg_basics.en.html#s-conffile
+gflags.DEFINE_multistring(
+    'conffile', None,
+    'List of conffiles (prefix item with @ to provide a path)')
+
+
+def MakeGflags():
+    """Creates a flag for each of the control file fields."""
+    for field in DEBIAN_FIELDS:
+        fieldname = field[0].replace('-', '_').lower()
+        msg = 'The value for the %s content header entry.' % field[0]
+        if len(field) > 3:
+            if isinstance(field[3], list):
+                gflags.DEFINE_multistring(fieldname, field[3], msg)
+            else:
+                gflags.DEFINE_string(fieldname, field[3], msg)
+        else:
+            gflags.DEFINE_string(fieldname, None, msg)
+        if field[1]:
+            gflags.MarkFlagAsRequired(fieldname)
+
+
+def ConvertToFileLike(content, content_len, converter):
+    if content_len < 0:
+        content_len = len(content)
+    content = converter(content)
+    return content_len, content
+
+
+def AddArFileEntry(fileobj, filename,
+                   content='', content_len=-1, timestamp=0,
+                   owner_id=0, group_id=0, mode=0o644):
+    """Add a AR file entry to fileobj."""
+    # If we got the content as a string, turn it into a file like thing.
+    if isinstance(content, (str, bytes)):
+        content_len, content = ConvertToFileLike(content, content_len, BytesIO)
+    inputs = [
+        (filename + '/').ljust(16),  # filename (SysV)
+        str(timestamp).ljust(12),  # timestamp
+        str(owner_id).ljust(6),  # owner id
+        str(group_id).ljust(6),  # group id
+        str(oct(mode)).replace('0o', '0').ljust(8),  # mode
+        str(content_len).ljust(10),  # size
+        '\x60\x0a',  # end of file entry
+    ]
+    for i in inputs:
+        fileobj.write(i.encode('ascii'))
+    size = 0
+    while True:
+        data = content.read(_COPY_CHUNK_SIZE)
+        if not data:
+            break
+        size += len(data)
+        fileobj.write(data)
+    if size % 2 != 0:
+        fileobj.write(b'\n')  # 2-byte alignment padding
+
+
+def MakeDebianControlField(name, value, wrap=False):
+    """Add a field to a debian control file."""
+    result = name + ': '
+    if isinstance(value, str):
+        value = value.decode('utf-8')
+    if isinstance(value, list):
+        value = u', '.join(value)
+    if wrap:
+        result += u' '.join(value.split('\n'))
+        result = textwrap.fill(result,
+                               break_on_hyphens=False,
+                               break_long_words=False)
+    else:
+        result += value
+    return result.replace(u'\n', u'\n ') + u'\n'
+
+
+def CreateDebControl(extrafiles=None, **kwargs):
+    """Create the control.tar.gz file."""
+    # create the control file
+    controlfile = ''
+    for values in DEBIAN_FIELDS:
+        fieldname = values[0]
+        key = fieldname[0].lower() + fieldname[1:].replace('-', '')
+        if values[1] or (key in kwargs and kwargs[key]):
+            controlfile += MakeDebianControlField(fieldname, kwargs[key], values[2])
+    # Create the control.tar file
+    tar = BytesIO()
+    with gzip.GzipFile('control.tar.gz', mode='w', fileobj=tar, mtime=0) as gz:
+        with tarfile.open('control.tar.gz', mode='w', fileobj=gz) as f:
+            tarinfo = tarfile.TarInfo('control')
+            # Don't discard unicode characters when computing the size
+            tarinfo.size = len(controlfile.encode('utf-8'))
+            f.addfile(tarinfo, fileobj=BytesIO(controlfile.encode('utf-8')))
+            if extrafiles:
+                for name, (data, mode) in extrafiles.items():
+                    tarinfo = tarfile.TarInfo(name)
+                    tarinfo.size = len(data)
+                    tarinfo.mode = mode
+                    f.addfile(tarinfo, fileobj=BytesIO(data.encode('utf-8')))
+    control = tar.getvalue()
+    tar.close()
+    return control
+
+
+def CreateDeb(output,
+              data,
+              preinst=None,
+              postinst=None,
+              prerm=None,
+              postrm=None,
+              conffiles=None,
+              **kwargs):
+    """Create a full debian package."""
+    extrafiles = {}
+    if preinst:
+        extrafiles['preinst'] = (preinst, 0o755)
+    if postinst:
+        extrafiles['postinst'] = (postinst, 0o755)
+    if prerm:
+        extrafiles['prerm'] = (prerm, 0o755)
+    if postrm:
+        extrafiles['postrm'] = (postrm, 0o755)
+    if conffiles:
+        extrafiles['conffiles'] = ('\n'.join(conffiles) + '\n', 0o644)
+    control = CreateDebControl(extrafiles=extrafiles, **kwargs)
+
+    # Write the final AR archive (the deb package)
+    with open(output, 'wb') as f:
+        f.write(b'!<arch>\n')  # Magic AR header
+        AddArFileEntry(f, 'debian-binary', b'2.0\n')
+        AddArFileEntry(f, 'control.tar.gz', control)
+        # Tries to preserve the extension name
+        ext = os.path.basename(data).split('.')[-2:]
+        if len(ext) < 2:
+            ext = 'tar'
+        elif ext[1] == 'tgz':
+            ext = 'tar.gz'
+        elif ext[1] == 'tar.bzip2':
+            ext = 'tar.bz2'
+        else:
+            ext = '.'.join(ext)
+            if ext not in ['tar.bz2', 'tar.gz', 'tar.xz', 'tar.lzma']:
+                ext = 'tar'
+        data_size = os.stat(data).st_size
+        with open(data, 'rb') as datafile:
+            AddArFileEntry(f, 'data.' + ext, datafile, content_len=data_size)
+
+
+def GetChecksumsFromFile(filename, hash_fns=None):
+    """Computes MD5 and/or other checksums of a file.
+
+    Args:
+      filename: Name of the file.
+      hash_fns: Mapping of hash functions.
+                Default is {'md5': hashlib.md5}
+
+    Returns:
+      Mapping of hash names to hexdigest strings.
+      { <hashname>: <hexdigest>, ... }
+    """
+    hash_fns = hash_fns or {'md5': hashlib.md5}
+    checksums = {k: fn() for (k, fn) in hash_fns.items()}
+
+    with open(filename, 'rb') as file_handle:
+        while True:
+            buf = file_handle.read(1048576)  # 1 MiB
+            if not buf:
+                break
+            for hashfn in checksums.values():
+                hashfn.update(buf)
+
+    return {k: fn.hexdigest() for (k, fn) in checksums.items()}
+
+
+def CreateChanges(output,
+                  deb_file,
+                  architecture,
+                  short_description,
+                  maintainer,
+                  package,
+                  version,
+                  section,
+                  priority,
+                  distribution,
+                  urgency,
+                  timestamp=0):
+    """Create the changes file."""
+    checksums = GetChecksumsFromFile(deb_file, {'md5': hashlib.md5,
+                                                'sha1': hashlib.sha1,
+                                                'sha256': hashlib.sha256})
+    debsize = str(os.path.getsize(deb_file))
+    deb_basename = os.path.basename(deb_file)
+
+    changesdata = ''.join([
+        MakeDebianControlField('Format', '1.8'),
+        MakeDebianControlField('Date', time.ctime(timestamp)),
+        MakeDebianControlField('Source', package),
+        MakeDebianControlField('Binary', package),
+        MakeDebianControlField('Architecture', architecture),
+        MakeDebianControlField('Version', version),
+        MakeDebianControlField('Distribution', distribution),
+        MakeDebianControlField('Urgency', urgency),
+        MakeDebianControlField('Maintainer', maintainer),
+        MakeDebianControlField('Changed-By', maintainer),
+        MakeDebianControlField('Description',
+                               '\n%s - %s' % (package, short_description)),
+        MakeDebianControlField('Changes',
+                               ('\n%s (%s) %s; urgency=%s'
+                                '\nChanges are tracked in revision control.') %
+                               (package, version, distribution, urgency)),
+        MakeDebianControlField(
+            'Files', '\n' + ' '.join(
+                [checksums['md5'], debsize, section, priority, deb_basename])),
+        MakeDebianControlField(
+            'Checksums-Sha1',
+            '\n' + ' '.join([checksums['sha1'], debsize, deb_basename])),
+        MakeDebianControlField(
+            'Checksums-Sha256',
+            '\n' + ' '.join([checksums['sha256'], debsize, deb_basename]))
+    ])
+    with open(output, 'w') as changes_fh:
+        changes_fh.write(changesdata.encode('utf-8'))
+
+
+def GetFlagValue(flagvalue, strip=True):
+    if flagvalue:
+        flagvalue = flagvalue.decode('utf-8')
+        if flagvalue[0] == '@':
+            with open(flagvalue[1:], 'r') as f:
+                flagvalue = f.read().decode('utf-8')
+        if strip:
+            return flagvalue.strip()
+    return flagvalue
+
+
+def GetFlagValues(flagvalues):
+    if flagvalues:
+        return [GetFlagValue(f, False) for f in flagvalues]
+    else:
+        return None
+
+
+def main(unused_argv):
+    CreateDeb(
+        FLAGS.output,
+        FLAGS.data,
+        preinst=GetFlagValue(FLAGS.preinst, False),
+        postinst=GetFlagValue(FLAGS.postinst, False),
+        prerm=GetFlagValue(FLAGS.prerm, False),
+        postrm=GetFlagValue(FLAGS.postrm, False),
+        conffiles=GetFlagValues(FLAGS.conffile),
+        package=FLAGS.package,
+        version=GetFlagValue(FLAGS.version),
+        description=GetFlagValue(FLAGS.description),
+        maintainer=FLAGS.maintainer,
+        section=FLAGS.section,
+        architecture=FLAGS.architecture,
+        depends=FLAGS.depends,
+        suggests=FLAGS.suggests,
+        enhances=FLAGS.enhances,
+        preDepends=FLAGS.pre_depends,
+        recommends=FLAGS.recommends,
+        homepage=FLAGS.homepage,
+        builtUsing=GetFlagValue(FLAGS.built_using),
+        priority=FLAGS.priority,
+        conflicts=FLAGS.conflicts,
+        installedSize=GetFlagValue(FLAGS.installed_size))
+    CreateChanges(
+        output=FLAGS.changes,
+        deb_file=FLAGS.output,
+        architecture=FLAGS.architecture,
+        short_description=GetFlagValue(FLAGS.description).split('\n')[0],
+        maintainer=FLAGS.maintainer, package=FLAGS.package,
+        version=GetFlagValue(FLAGS.version), section=FLAGS.section,
+        priority=FLAGS.priority, distribution=FLAGS.distribution,
+        urgency=FLAGS.urgency)
+
+if __name__ == '__main__':
+    MakeGflags()
+    FLAGS = gflags.FLAGS
+    main(FLAGS(sys.argv))

--- a/apt/pkg_deb_modified_from_bazel/path.bzl
+++ b/apt/pkg_deb_modified_from_bazel/path.bzl
@@ -1,0 +1,56 @@
+# Copyright 2016 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Helper functions that don't depend on Skylark, so can be unit tested."""
+
+def _short_path_dirname(path):
+    """Returns the directory's name of the short path of an artifact."""
+    sp = path.short_path
+    last_pkg = sp.rfind("/")
+    if last_pkg == -1:
+        # Top-level BUILD file.
+        return ""
+    return sp[:last_pkg]
+
+def dest_path(f, strip_prefix):
+    """Returns the short path of f, stripped of strip_prefix."""
+    if strip_prefix == None:
+        # If no strip_prefix was specified, use the package of the
+        # given input as the strip_prefix.
+        strip_prefix = _short_path_dirname(f)
+    if not strip_prefix:
+        return f.short_path
+    if f.short_path.startswith(strip_prefix):
+        return f.short_path[len(strip_prefix):]
+    return f.short_path
+
+def compute_data_path(out, data_path):
+    """Compute the relative data path prefix from the data_path attribute."""
+    if data_path:
+        # Strip ./ from the beginning if specified.
+        # There is no way to handle .// correctly (no function that would make
+        # that possible and Skylark is not turing complete) so just consider it
+        # as an absolute path.
+        if len(data_path) >= 2 and data_path[0:2] == "./":
+            data_path = data_path[2:]
+        if not data_path or data_path == ".":  # Relative to current package
+            return _short_path_dirname(out)
+        elif data_path[0] == "/":  # Absolute path
+            return data_path[1:]
+        else:  # Relative to a sub-directory
+            tmp_short_path_dirname = _short_path_dirname(out)
+            if tmp_short_path_dirname:
+                return tmp_short_path_dirname + "/" + data_path
+            return data_path
+    else:
+        return None

--- a/apt/pkg_deb_modified_from_bazel/pkg.bzl
+++ b/apt/pkg_deb_modified_from_bazel/pkg.bzl
@@ -1,0 +1,309 @@
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Rules for manipulation of various packaging."""
+
+load(":path.bzl", "compute_data_path", "dest_path")
+
+# Filetype to restrict inputs
+tar_filetype = [".tar", ".tar.gz", ".tgz", ".tar.xz", ".tar.bz2"]
+deb_filetype = [".deb", ".udeb"]
+
+def _remap(remap_paths, path):
+    """If path starts with a key in remap_paths, rewrite it."""
+    for prefix, replacement in remap_paths.items():
+        if path.startswith(prefix):
+            return replacement + path[len(prefix):]
+    return path
+
+def _quote(filename, protect = "="):
+    """Quote the filename, by escaping = by \= and \ by \\"""
+    return filename.replace("\\", "\\\\").replace(protect, "\\" + protect)
+
+def _pkg_tar_impl(ctx):
+    """Implementation of the pkg_tar rule."""
+
+    # Compute the relative path
+    data_path = compute_data_path(ctx.outputs.out, ctx.attr.strip_prefix)
+
+    # Find a list of path remappings to apply.
+    remap_paths = ctx.attr.remap_paths
+
+    # Start building the arguments.
+    args = [
+        "--output=" + ctx.outputs.out.path,
+        "--directory=" + ctx.attr.package_dir,
+        "--mode=" + ctx.attr.mode,
+        "--owner=" + ctx.attr.owner,
+        "--owner_name=" + ctx.attr.ownername,
+    ]
+    if ctx.attr.mtime != -1:  # Note: Must match default in rule def.
+        if ctx.attr.portable_mtime:
+            fail("You may not set both mtime and portable_mtime")
+        args.append("--mtime=" + ctx.attr.mtime)
+    if ctx.attr.portable_mtime:
+        args.append("--mtime=portable")
+
+    # Add runfiles if requested
+    file_inputs = []
+    if ctx.attr.include_runfiles:
+        runfiles_depsets = []
+        for f in ctx.attr.srcs:
+            default_runfiles = f[DefaultInfo].default_runfiles
+            if default_runfiles != None:
+                runfiles_depsets.append(default_runfiles.files)
+
+        # deduplicates files in srcs attribute and their runfiles
+        file_inputs = depset(ctx.files.srcs, transitive = runfiles_depsets).to_list()
+    else:
+        file_inputs = ctx.files.srcs[:]
+
+    args += [
+        "--file=%s=%s" % (_quote(f.path), _remap(remap_paths, dest_path(f, data_path)))
+        for f in file_inputs
+    ]
+    for target, f_dest_path in ctx.attr.files.items():
+        target_files = target.files.to_list()
+        if len(target_files) != 1:
+            fail("Each input must describe exactly one file.", attr = "files")
+        file_inputs += target_files
+        args += ["--file=%s=%s" % (_quote(target_files[0].path), f_dest_path)]
+    if ctx.attr.modes:
+        args += [
+            "--modes=%s=%s" % (_quote(key), ctx.attr.modes[key])
+            for key in ctx.attr.modes
+        ]
+    if ctx.attr.owners:
+        args += [
+            "--owners=%s=%s" % (_quote(key), ctx.attr.owners[key])
+            for key in ctx.attr.owners
+        ]
+    if ctx.attr.ownernames:
+        args += [
+            "--owner_names=%s=%s" % (_quote(key), ctx.attr.ownernames[key])
+            for key in ctx.attr.ownernames
+        ]
+    if ctx.attr.empty_files:
+        args += ["--empty_file=%s" % empty_file for empty_file in ctx.attr.empty_files]
+    if ctx.attr.empty_dirs:
+        args += ["--empty_dir=%s" % empty_dir for empty_dir in ctx.attr.empty_dirs]
+    if ctx.attr.extension:
+        dotPos = ctx.attr.extension.find(".")
+        if dotPos > 0:
+            dotPos += 1
+            args += ["--compression=%s" % ctx.attr.extension[dotPos:]]
+        elif ctx.attr.extension == "tgz":
+            args += ["--compression=gz"]
+    args += ["--tar=" + f.path for f in ctx.files.deps]
+    args += [
+        "--link=%s:%s" % (_quote(k, protect = ":"), ctx.attr.symlinks[k])
+        for k in ctx.attr.symlinks
+    ]
+    arg_file = ctx.actions.declare_file(ctx.label.name + ".args")
+    ctx.actions.write(arg_file, "\n".join(args))
+
+    ctx.actions.run(
+        inputs = file_inputs + ctx.files.deps + [arg_file],
+        executable = ctx.executable.build_tar,
+        arguments = ["--flagfile", arg_file.path],
+        outputs = [ctx.outputs.out],
+        mnemonic = "PackageTar",
+        use_default_shell_env = True,
+    )
+
+def _pkg_deb_impl(ctx):
+    """The implementation for the pkg_deb rule."""
+    files = [ctx.file.data]
+    args = [
+        "--output=" + ctx.outputs.deb.path,
+        "--changes=" + ctx.outputs.changes.path,
+        "--data=" + ctx.file.data.path,
+        "--package=" + ctx.attr.package,
+        "--architecture=" + ctx.attr.architecture,
+        "--maintainer=" + ctx.attr.maintainer,
+    ]
+    if ctx.attr.preinst:
+        args += ["--preinst=@" + ctx.file.preinst.path]
+        files += [ctx.file.preinst]
+    if ctx.attr.postinst:
+        args += ["--postinst=@" + ctx.file.postinst.path]
+        files += [ctx.file.postinst]
+    if ctx.attr.prerm:
+        args += ["--prerm=@" + ctx.file.prerm.path]
+        files += [ctx.file.prerm]
+    if ctx.attr.postrm:
+        args += ["--postrm=@" + ctx.file.postrm.path]
+        files += [ctx.file.postrm]
+
+    # Conffiles can be specified by a file or a string list
+    if ctx.attr.conffiles_file:
+        if ctx.attr.conffiles:
+            fail("Both conffiles and conffiles_file attributes were specified")
+        args += ["--conffile=@" + ctx.file.conffiles_file.path]
+        files += [ctx.file.conffiles_file]
+    elif ctx.attr.conffiles:
+        args += ["--conffile=%s" % cf for cf in ctx.attr.conffiles]
+
+    # Version and description can be specified by a file or inlined
+    if ctx.attr.version_file:
+        if ctx.attr.version:
+            fail("Both version and version_file attributes were specified")
+        args += ["--version=@" + ctx.file.version_file.path]
+        files += [ctx.file.version_file]
+    elif ctx.attr.version:
+        args += ["--version=" + ctx.attr.version]
+    else:
+        fail("Neither version_file nor version attribute was specified")
+
+    if ctx.attr.description_file:
+        if ctx.attr.description:
+            fail("Both description and description_file attributes were specified")
+        args += ["--description=@" + ctx.file.description_file.path]
+        files += [ctx.file.description_file]
+    elif ctx.attr.description:
+        args += ["--description=" + ctx.attr.description]
+    else:
+        fail("Neither description_file nor description attribute was specified")
+
+    # Built using can also be specified by a file or inlined (but is not mandatory)
+    if ctx.attr.built_using_file:
+        if ctx.attr.built_using:
+            fail("Both build_using and built_using_file attributes were specified")
+        args += ["--built_using=@" + ctx.file.built_using_file.path]
+        files += [ctx.file.built_using_file]
+    elif ctx.attr.built_using:
+        args += ["--built_using=" + ctx.attr.built_using]
+
+    if ctx.attr.priority:
+        args += ["--priority=" + ctx.attr.priority]
+    if ctx.attr.section:
+        args += ["--section=" + ctx.attr.section]
+    if ctx.attr.homepage:
+        args += ["--homepage=" + ctx.attr.homepage]
+
+    args += ["--distribution=" + ctx.attr.distribution]
+    args += ["--urgency=" + ctx.attr.urgency]
+    args += ["--depends=" + d for d in ctx.attr.depends]
+    args += ["--suggests=" + d for d in ctx.attr.suggests]
+    args += ["--enhances=" + d for d in ctx.attr.enhances]
+    args += ["--conflicts=" + d for d in ctx.attr.conflicts]
+    args += ["--pre_depends=" + d for d in ctx.attr.predepends]
+    args += ["--recommends=" + d for d in ctx.attr.recommends]
+
+    ctx.actions.run(
+        executable = ctx.executable.make_deb,
+        arguments = args,
+        inputs = files,
+        outputs = [ctx.outputs.deb, ctx.outputs.changes],
+        mnemonic = "MakeDeb",
+    )
+    ctx.actions.run_shell(
+        command = "ln -s %s %s" % (ctx.outputs.deb.basename, ctx.outputs.out.path),
+        inputs = [ctx.outputs.deb],
+        outputs = [ctx.outputs.out],
+    )
+
+# A rule for creating a tar file, see README.md
+_real_pkg_tar = rule(
+    implementation = _pkg_tar_impl,
+    attrs = {
+        "strip_prefix": attr.string(),
+        "package_dir": attr.string(default = "/"),
+        "deps": attr.label_list(allow_files = tar_filetype),
+        "srcs": attr.label_list(allow_files = True),
+        "files": attr.label_keyed_string_dict(allow_files = True),
+        "mode": attr.string(default = "0555"),
+        "modes": attr.string_dict(),
+        "mtime": attr.int(default = -1),
+        "portable_mtime": attr.bool(default = True),
+        "owner": attr.string(default = "0.0"),
+        "ownername": attr.string(default = "."),
+        "owners": attr.string_dict(),
+        "ownernames": attr.string_dict(),
+        "extension": attr.string(default = "tar"),
+        "symlinks": attr.string_dict(),
+        "empty_files": attr.string_list(),
+        "include_runfiles": attr.bool(),
+        "empty_dirs": attr.string_list(),
+        "remap_paths": attr.string_dict(),
+        # Implicit dependencies.
+        "build_tar": attr.label(
+            default = Label("//tools/build_defs/pkg:build_tar"),
+            cfg = "host",
+            executable = True,
+            allow_files = True,
+        ),
+    },
+    outputs = {
+        "out": "%{name}.%{extension}",
+    },
+)
+
+def pkg_tar(**kwargs):
+    # Compatibility with older versions of pkg_tar that define files as
+    # a flat list of labels.
+    if "srcs" not in kwargs:
+        if "files" in kwargs:
+            if not hasattr(kwargs["files"], "items"):
+                label = "%s//%s:%s" % (native.repository_name(), native.package_name(), kwargs["name"])
+                print("%s: you provided a non dictionary to the pkg_tar `files` attribute. " % (label,) +
+                      "This attribute was renamed to `srcs`. " +
+                      "Consider renaming it in your BUILD file.")
+                kwargs["srcs"] = kwargs.pop("files")
+    _real_pkg_tar(**kwargs)
+
+# A rule for creating a deb file, see README.md
+pkg_deb = rule(
+    implementation = _pkg_deb_impl,
+    attrs = {
+        "data": attr.label(mandatory = True, allow_single_file = tar_filetype),
+        "package": attr.string(mandatory = True),
+        "architecture": attr.string(default = "all"),
+        "distribution": attr.string(default = "unstable"),
+        "urgency": attr.string(default = "medium"),
+        "maintainer": attr.string(mandatory = True),
+        "preinst": attr.label(allow_single_file = True),
+        "postinst": attr.label(allow_single_file = True),
+        "prerm": attr.label(allow_single_file = True),
+        "postrm": attr.label(allow_single_file = True),
+        "conffiles_file": attr.label(allow_single_file = True),
+        "conffiles": attr.string_list(default = []),
+        "version_file": attr.label(allow_single_file = True),
+        "version": attr.string(),
+        "description_file": attr.label(allow_single_file = True),
+        "description": attr.string(),
+        "built_using_file": attr.label(allow_single_file = True),
+        "built_using": attr.string(),
+        "priority": attr.string(),
+        "section": attr.string(),
+        "homepage": attr.string(),
+        "depends": attr.string_list(default = []),
+        "suggests": attr.string_list(default = []),
+        "enhances": attr.string_list(default = []),
+        "conflicts": attr.string_list(default = []),
+        "predepends": attr.string_list(default = []),
+        "recommends": attr.string_list(default = []),
+        # Implicit dependencies.
+        "make_deb": attr.label(
+            default = Label("//apt/pkg_deb_modified_from_bazel:make_deb"),
+            cfg = "host",
+            executable = True,
+            allow_files = True,
+        ),
+    },
+    outputs = {
+        "out": "%{name}.deb",
+        "deb": "%{package}_%{version}_%{architecture}.deb",
+        "changes": "%{package}_%{version}_%{architecture}.changes",
+    },
+)

--- a/rpm/rules.bzl
+++ b/rpm/rules.bzl
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("//rpm/pkg_rpm_modified_from_bazel:rules.bzl", "pkg_rpm")
 
 


### PR DESCRIPTION
## What is the goal of this PR?

`assemble_apt` should be able to embed version of package being built into its dependency — this way we can make `grakn-core-all=1.5.0` depend exactly on `grakn-core-console=1.5.0` and `grakn-core-server=1.5.0`

## What are the changes implemented in this PR?

- Vendored in `pkg_deb` from `bazel`
- Modified it to replace `{version}` with package version
- Make `installation_dir` non-mandatory so we're able to build empty packages (without files)
