### PR TITLE
Allow multiple java_deps in same file by renaming jars.mapping

### DIFF
--- a/common/rules.bzl
+++ b/common/rules.bzl
@@ -105,7 +105,7 @@ def _java_deps_impl(ctx):
             files.append(file)
             filenames.append(file.basename)
 
-    jars_mapping = ctx.actions.declare_file("jars.mapping")
+    jars_mapping = ctx.actions.declare_file("{}_jars.mapping".format(ctx.attr.target.label.name))
 
     ctx.actions.write(
         output = jars_mapping,


### PR DESCRIPTION
## What is the goal of this PR?

Fixes #93 

## What are the changes implemented in this PR?

`jars.mapping` is now prefix by `target`'s label name, which is unique across targets in same package.