### PR TITLE
Distribution versioning and checksum

### DIFF
--- a/brew/rules.bzl
+++ b/brew/rules.bzl
@@ -39,10 +39,6 @@ def _deploy_brew_impl(ctx):
 
 deploy_brew = rule(
     attrs = {
-        "_deploy_brew_template": attr.label(
-            allow_single_file = True,
-            default = "//brew/templates:deploy.py"
-        ),
         "checksum": attr.label(
             allow_single_file = True,
         ),
@@ -62,7 +58,11 @@ deploy_brew = rule(
         "version_file": attr.label(
             allow_single_file = True,
             mandatory = True
-        )
+        ),
+        "_deploy_brew_template": attr.label(
+            allow_single_file = True,
+            default = "//brew/templates:deploy.py"
+        ),
     },
     executable = True,
     outputs = {

--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -70,7 +70,7 @@ checksum_of_distribution_local = get_checksum()
 tap_localpath = tempfile.mkdtemp()
 try:
     print('Cloning brew tap: "{}"...'.format(tap_url))
-    sp.check_call(['git', 'clone', tap_url, tap_localpath])
+    sp.check_call(['bash', '-c', 'git clone ' + url_with_credential(tap_url, '$DEPLOY_BREW_TOKEN') + ' ' + tap_localpath])
     sp.check_call(['mkdir', '-p', '{brew_folder}'], cwd=tap_localpath)
     formula_content = formula_template.replace('{version}', version).replace('{sha256}', checksum_of_distribution_local)
     distribution_url = get_distribution_url_from_formula(formula_content)
@@ -87,7 +87,12 @@ try:
         f.write(formula_content)
     sp.check_call(['git', 'add', '.'], cwd=tap_localpath)
     try:
-        sp.check_call(['git', 'commit', '-m', 'Update the {} formula to {}'.format(formula_filename, version)], cwd=tap_localpath)
+        # the command returns 1 if there is a staged file. otherwise, it will return 0
+        should_commit = sp.call(["git", "diff", "--staged", "--exit-code"], cwd=tap_localpath) == 1
+        if should_commit:
+            sp.check_call(['git', 'commit', '-m', 'Update the {} formula to {}'.format(formula_filename, version)], cwd=tap_localpath)
+        else:
+            print('Formula {} is already at version {}! there is nothing to commit.'.format(formula_filename, version_file))
     except sp.CalledProcessError as e:
         print('Error - unable to proceed with deploying to brew due to the following error:')
         raise e

--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -56,6 +56,8 @@ if len(sys.argv) != 2:
 
 
 # configurations #
+git_username = 'Grabl'
+git_email = 'grabl@grakn.ai'
 properties = parse_deployment_properties('deployment.properties')
 formula_filename = os.path.basename(os.readlink('formula'))
 with open('formula') as formula_file:
@@ -69,6 +71,8 @@ checksum_of_distribution_local = get_checksum()
 
 tap_localpath = tempfile.mkdtemp()
 try:
+    sp.check_call(["git", "config", "user.email", git_email], cwd=tap_localpath)
+    sp.check_call(["git", "config", "user.name", git_username], cwd=tap_localpath)
     print('Cloning brew tap: "{}"...'.format(tap_url))
     sp.check_call(['bash', '-c', 'git clone ' + url_with_credential(tap_url, '$DEPLOY_BREW_TOKEN') + ' ' + tap_localpath])
     sp.check_call(['mkdir', '-p', '{brew_folder}'], cwd=tap_localpath)

--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -71,10 +71,10 @@ checksum_of_distribution_local = get_checksum()
 
 tap_localpath = tempfile.mkdtemp()
 try:
-    sp.check_call(["git", "config", "user.email", git_email], cwd=tap_localpath)
-    sp.check_call(["git", "config", "user.name", git_username], cwd=tap_localpath)
     print('Cloning brew tap: "{}"...'.format(tap_url))
     sp.check_call(['bash', '-c', 'git clone ' + url_with_credential(tap_url, '$DEPLOY_BREW_TOKEN') + ' ' + tap_localpath])
+    sp.check_call(["git", "config", "user.email", git_email], cwd=tap_localpath)
+    sp.check_call(["git", "config", "user.name", git_username], cwd=tap_localpath)
     sp.check_call(['mkdir', '-p', '{brew_folder}'], cwd=tap_localpath)
     formula_content = formula_template.replace('{version}', version).replace('{sha256}', checksum_of_distribution_local)
     distribution_url = get_distribution_url_from_formula(formula_content)

--- a/common/BUILD
+++ b/common/BUILD
@@ -29,3 +29,9 @@ py_binary(
     srcs = ["tgz2zip.py"],
     visibility = ["//visibility:public"]
 )
+
+py_binary(
+    name = "assemble-versioned",
+    srcs = ["assemble-versioned.py"],
+    visibility = ["//visibility:public"]
+)

--- a/common/assemble-versioned.py
+++ b/common/assemble-versioned.py
@@ -54,6 +54,7 @@ def tar_repackage_with_version(original_tarfile, version):
             tarfile.open(repackaged_tarfile, mode='w:gz') as repackaged_tar:
         for info in sorted(original_tar.getmembers()):
             info.path = info.path.replace(original_tar_basedir, repackaged_tar_basedir, 1)
+            info.mtime = 0
             content = original_tar.extractfile(info)
             repackaged_tar.addfile(info, content)
     return repackaged_tarfile
@@ -73,7 +74,7 @@ print('pwd = {}'.format(os.getcwd()))
 # print('directory = {}'.format(directory_to_upload))
 
 with ZipFile(output_path, 'w', compression=zipfile.ZIP_DEFLATED) as output:
-    for target in target_paths:
+    for target in sorted(target_paths):
         if target.endswith('zip'):
             zip = zip_repackage_with_version(target, version)
             output.write(zip, os.path.basename(zip))

--- a/common/assemble-versioned.py
+++ b/common/assemble-versioned.py
@@ -52,8 +52,9 @@ def tar_repackage_with_version(original_tarfile, version):
     repackaged_tarfile = repackaged_tar_basedir+'.'+ext
     with tarfile.open(original_tarfile, mode='r:gz') as original_tar, \
             tarfile.open(repackaged_tarfile, mode='w:gz') as repackaged_tar:
-        for orig in sorted(original_tar.getmembers()):
-            repackaged_tar.addfile(orig)
+        for info in sorted(original_tar.getmembers()):
+            content = original_tar.extractfile(info)
+            repackaged_tar.addfile(info, content)
     return repackaged_tarfile
 
 

--- a/common/assemble-versioned.py
+++ b/common/assemble-versioned.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+import os
+import shutil
+import sys
+import tarfile
+import zipfile
+
+
+# This ZipFile extends Python's ZipFile and fixes the lost permission issue
+class ZipFile(zipfile.ZipFile):
+    def extract(self, member, path=None, pwd=None):
+        if not isinstance(member, zipfile.ZipInfo):
+            member = self.getinfo(member)
+
+        if path is None:
+            path = os.getcwd()
+
+        ret_val = self._extract_member(member, path, pwd)
+        attr = member.external_attr >> 16
+        os.chmod(ret_val, attr)
+        return ret_val
+
+
+def zip_repackage_with_version(original_zipfile, version, directory_to_upload):
+    ext = 'zip'
+    original_zip_basedir = original_zipfile[:-len(ext) - 1]
+    repackaged_zip_basedir = '{}-{}'.format(original_zip_basedir, version)
+    repackaged_zipfile = repackaged_zip_basedir+'.zip'
+    with ZipFile(original_zipfile, 'r') as original_zip, \
+            ZipFile(repackaged_zipfile, 'w', compression=zipfile.ZIP_DEFLATED) as repackaged_zip:
+        for orig in sorted(original_zip.infolist()):
+            f = ''
+            name = './' + os.path.normpath(os.path.join(orig.filename))
+            if not orig.filename.endswith('/'):
+                f = original_zip.read(orig)
+            else:
+                name += '/'
+            repkg = zipfile.ZipInfo(name)
+            repkg.compress_type = zipfile.ZIP_DEFLATED
+            repkg.external_attr = orig.external_attr
+            repkg.date_time = orig.date_time
+            repackaged_zip.writestr(repkg, f)
+
+    return repackaged_zipfile
+
+
+def tar_repackage_with_version(original_archive, version, directory_to_upload):
+    extension = 'tar.gz'
+    original_archive_basedir = original_archive[:-len(extension) - 1]
+    repackaged_archive_basedir = '{}-{}'.format(original_archive_basedir, version)
+    tarfile.open(original_archive, mode='r:gz').extractall()
+    os.rename(original_archive_basedir, repackaged_archive_basedir)
+    repackaged_archive = shutil.make_archive(base_name=repackaged_archive_basedir, format='gztar', base_dir=repackaged_archive_basedir)
+
+
+output_path = sys.argv[1]
+version_path = sys.argv[2]
+target_paths = sys.argv[3:]
+
+version = '1.5.0' # open(version_path, 'r').read()
+
+print('output = ' + str(output_path))
+print('version = ' + str(version_path))
+print('target = ' + str(target_paths))
+
+print('pwd = {}'.format(os.getcwd()))
+# print('directory = {}'.format(directory_to_upload))
+
+with ZipFile(output_path, 'w', compression=zipfile.ZIP_DEFLATED) as output:
+    for fl in target_paths:
+        if fl.endswith('zip'):
+            zip = zip_repackage_with_version(fl, version, '.')
+            output.write(zip)
+        elif fl.endswith('tar.gz'):
+            tar_repackage_with_version(fl, version, '.')
+        else:
+            raise ValueError('This file is neither a zip nor a tar.gz: {}'.format(fl))

--- a/common/assemble-versioned.py
+++ b/common/assemble-versioned.py
@@ -64,12 +64,6 @@ output_path = sys.argv[1]
 version_path = sys.argv[2]
 target_paths = sys.argv[3:]
 
-print('output = ' + str(output_path))
-print('version = ' + str(version_path))
-print('target = ' + str(target_paths))
-print('pwd = {}'.format(os.getcwd()))
-
-
 version = open(version_path, 'r').read().strip()
 
 with ZipFile(output_path, 'w', compression=zipfile.ZIP_DEFLATED) as output:

--- a/common/assemble-versioned.py
+++ b/common/assemble-versioned.py
@@ -64,14 +64,13 @@ output_path = sys.argv[1]
 version_path = sys.argv[2]
 target_paths = sys.argv[3:]
 
-version = '1.5.0' # open(version_path, 'r').read()
-
 print('output = ' + str(output_path))
 print('version = ' + str(version_path))
 print('target = ' + str(target_paths))
-
 print('pwd = {}'.format(os.getcwd()))
-# print('directory = {}'.format(directory_to_upload))
+
+
+version = open(version_path, 'r').read().strip()
 
 with ZipFile(output_path, 'w', compression=zipfile.ZIP_DEFLATED) as output:
     for target in sorted(target_paths):

--- a/common/assemble-versioned.py
+++ b/common/assemble-versioned.py
@@ -73,12 +73,11 @@ print('pwd = {}'.format(os.getcwd()))
 
 with ZipFile(output_path, 'w', compression=zipfile.ZIP_DEFLATED) as output:
     for target in target_paths:
-        filename = os.path.basename(target)
         if target.endswith('zip'):
             zip = zip_repackage_with_version(target, version)
-            output.write(zip, filename)
+            output.write(zip, os.path.basename(zip))
         elif target.endswith('tar.gz'):
             tar = tar_repackage_with_version(target, version)
-            output.write(tar, filename)
+            output.write(tar, os.path.basename(tar))
         else:
             raise ValueError('This file is neither a zip nor a tar.gz: {}'.format(target))

--- a/common/assemble-versioned.py
+++ b/common/assemble-versioned.py
@@ -29,7 +29,7 @@ def zip_repackage_with_version(original_zipfile, version):
     repackaged_zipfile = repackaged_zip_basedir+'.'+ext
     with ZipFile(original_zipfile, 'r') as original_zip, \
             ZipFile(repackaged_zipfile, 'w', compression=zipfile.ZIP_DEFLATED) as repackaged_zip:
-        for orig_info in sorted(original_zip.infolist()):
+        for orig_info in sorted(original_zip.infolist(), key=lambda info: info.filename):
             repkg_name = orig_info.filename
             repkg_content = ''
             if not orig_info.filename.endswith('/'):
@@ -52,7 +52,7 @@ def tar_repackage_with_version(original_tarfile, version):
     repackaged_tarfile = repackaged_tar_basedir+'.'+ext
     with tarfile.open(original_tarfile, mode='r:gz') as original_tar, \
             tarfile.open(repackaged_tarfile, mode='w:gz') as repackaged_tar:
-        for info in sorted(original_tar.getmembers()):
+        for info in sorted(original_tar.getmembers(), key=lambda info: info.path):
             info.path = info.path.replace(original_tar_basedir, repackaged_tar_basedir, 1)
             info.mtime = 0
             content = original_tar.extractfile(info)

--- a/common/assemble-versioned.py
+++ b/common/assemble-versioned.py
@@ -45,19 +45,6 @@ def zip_repackage_with_version(original_zipfile, version):
     return repackaged_zipfile
 
 
-# def tar_repackage_with_version(original_archive, version, directory_to_upload):
-#     extension = 'tar.gz'
-#     original_archive_basedir = original_archive[:-len(extension) - 1]
-#     repackaged_archive_basedir = '{}-{}'.format(original_archive_basedir, version)
-#     tarfile.open(original_archive, mode='r:gz').extractall()
-#     print('')
-#     print('original_archive_basedir = {}'.format(original_archive_basedir))
-#     print('repackaged_archive_basedir = {}'.format(repackaged_archive_basedir))
-#     os.rename(original_archive_basedir, repackaged_archive_basedir)
-#     repackaged_archive = shutil.make_archive(base_name=repackaged_archive_basedir, format='gztar', base_dir=repackaged_archive_basedir)
-#     return repackaged_archive
-
-
 def tar_repackage_with_version(original_tarfile, version):
     ext = 'tar.gz'
     original_tar_basedir = original_tarfile[:-len(ext) - 1]
@@ -88,9 +75,9 @@ with ZipFile(output_path, 'w', compression=zipfile.ZIP_DEFLATED) as output:
         filename = os.path.basename(target)
         if target.endswith('zip'):
             zip = zip_repackage_with_version(target, version)
-            output.write(zip, target)
+            output.write(zip, filename)
         elif target.endswith('tar.gz'):
             tar = tar_repackage_with_version(target, version)
-            output.write(tar, target)
+            output.write(tar, filename)
         else:
             raise ValueError('This file is neither a zip nor a tar.gz: {}'.format(target))

--- a/common/rules.bzl
+++ b/common/rules.bzl
@@ -286,14 +286,14 @@ assemble_versioned = rule(
 
 def _checksum(ctx):
     ctx.actions.run_shell(
-        inputs = [ctx.file.target],
+        inputs = [ctx.file.archive],
         outputs = [ctx.outputs.checksum_file],
-        command = 'shasum -a 256 {} > {}'.format(ctx.file.target.path, ctx.outputs.checksum_file.path)
+        command = 'mkdir tmp; unzip {} -d tmp; shasum -a 256 tmp/* > {}; rm -rf tmp/'.format(ctx.file.archive.path, ctx.outputs.checksum_file.path)
     )
 
 checksum = rule(
     attrs = {
-        'target': attr.label(allow_single_file = True, mandatory = True)
+        'archive': attr.label(allow_single_file = True, mandatory = True)
     },
     outputs = {
         'checksum_file': '%{name}.sha256'

--- a/common/rules.bzl
+++ b/common/rules.bzl
@@ -251,7 +251,7 @@ def assemble_zip(name,
 def _assemble_versioned_impl(ctx):
     # assemble-version.py $output $version $targets
     ctx.actions.run(
-        inputs = ctx.files.targets,
+        inputs = ctx.files.targets + [ctx.file.version_file],
         outputs = [ctx.outputs.archive],
         executable = ctx.executable._assemble_versioned_py,
         arguments = [ctx.outputs.archive.path, ctx.file.version_file.path] + [target.path for target in ctx.files.targets],

--- a/common/rules.bzl
+++ b/common/rules.bzl
@@ -248,6 +248,42 @@ def assemble_zip(name,
     )
 
 
+def _assemble_versioned_impl(ctx):
+    # assemble-version.py $output $version $targets
+    ctx.actions.run(
+        inputs = ctx.files.targets,
+        outputs = [ctx.outputs.archive],
+        executable = ctx.executable._assemble_versioned_py,
+        arguments = [ctx.outputs.archive.path, ctx.file.version_file.path] + [target.path for target in ctx.files.targets],
+        progress_message = "Versioning assembled distributions to {}".format(ctx.attr.version_file.label)
+    )
+
+    return DefaultInfo(data_runfiles = ctx.runfiles(files=[ctx.outputs.archive]))
+
+assemble_versioned = rule(
+    attrs = {
+        "targets": attr.label_list(
+            allow_files = [".zip", ".tar.gz"]
+        ),
+        "version_file": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "File containing version string"
+        ),
+        "_assemble_versioned_py": attr.label(
+            default = "//common:assemble-versioned",
+            executable = True,
+            cfg = "host"
+        )
+    },
+    implementation = _assemble_versioned_impl,
+    outputs = {
+        "archive": "%{name}.zip"
+    },
+    output_to_genfiles = True
+)
+
+
 def _checksum(ctx):
     ctx.actions.run_shell(
         inputs = [ctx.file.target],

--- a/github/deploy.py
+++ b/github/deploy.py
@@ -110,10 +110,9 @@ try:
         '-u', github_organisation,
         '-r', github_repository,
         '-b', open('release_description.txt').read() if has_release_description else '',
-        '-delete', '-draft', github_tag,
+        '-delete', '-draft', github_tag, # TODO: tag must reference the current commit
         directory_to_upload
     ], env={'GITHUB_TOKEN': github_token})
 finally:
     shutil.rmtree(directory_to_upload)
-
 sys.exit(exit_code)

--- a/github/deploy.py
+++ b/github/deploy.py
@@ -41,14 +41,6 @@ def parse_deployment_properties(fn):
     return deployment_properties
 
 
-targets = [] if not "{targets}" else "{targets}".split(',')
-has_release_description = bool(int("{has_release_description}"))
-
-properties = parse_deployment_properties('deployment.properties')
-github_organisation = properties['repo.github.organisation']
-github_repository = properties['repo.github.repository']
-
-
 def get_github_token():
     if 'DEPLOY_GITHUB_TOKEN' in os.environ:
         return os.getenv('DEPLOY_GITHUB_TOKEN')
@@ -64,6 +56,13 @@ def get_github_token():
 
 
 github_token = get_github_token()
+
+targets = [] if not "{targets}" else "{targets}".split(',')
+has_release_description = bool(int("{has_release_description}"))
+
+properties = parse_deployment_properties('deployment.properties')
+github_organisation = properties['repo.github.organisation']
+github_repository = properties['repo.github.repository']
 
 with open('VERSION') as version_file:
     distribution_version = version_file.read().strip()
@@ -93,15 +92,18 @@ dummy_directory = tempfile.mkdtemp(dir=directory_to_upload)
 for fl in targets:
     if fl.endswith('zip'):
         extension = 'zip'
+        filename = fl[:-len(extension)-1]
+        final_name = os.path.basename('{}-{}.{}'.format(filename, distribution_version, extension))
+
+        shutil.copy(fl, os.path.join(directory_to_upload, final_name))
     elif fl.endswith('tar.gz'):
         extension = 'tar.gz'
+        filename = fl[:-len(extension)-1]
+        final_name = os.path.basename('{}-{}.{}'.format(filename, distribution_version, extension))
+
+        shutil.copy(fl, os.path.join(directory_to_upload, final_name))
     else:
         raise ValueError('This file is neither a zip nor a tar.gz: {}'.format(fl))
-
-    filename = fl[:-len(extension)-1]
-    final_name = os.path.basename('{}-{}.{}'.format(filename, distribution_version, extension))
-    shutil.copy(fl, os.path.join(directory_to_upload, final_name))
-
 try:
     subprocess.call([
         ghr,

--- a/github/deploy.py
+++ b/github/deploy.py
@@ -24,7 +24,7 @@ import os
 import shutil
 import platform
 import glob
-import subprocess
+import subprocess as sp
 import tempfile
 
 
@@ -71,10 +71,10 @@ with open('VERSION') as version_file:
 system = platform.system()
 tempdir = tempfile.mkdtemp()
 if system == 'Darwin':
-    subprocess.call(['unzip', 'external/ghr_osx_zip/file/downloaded', '-d', tempdir])
+    sp.call(['unzip', 'external/ghr_osx_zip/file/downloaded', '-d', tempdir])
     ghr = glob.glob(os.path.join(tempdir, '**/ghr'))[0]
 elif system == 'Linux':
-    subprocess.call(['tar', '-xf', 'external/ghr_linux_tar/file/downloaded', '-C', tempdir])
+    sp.call(['tar', '-xf', 'external/ghr_linux_tar/file/downloaded', '-C', tempdir])
     ghr = glob.glob(os.path.join(tempdir, '**/ghr'))[0]
 else:
     print('Error - your platform ({}) is not supported. Try Linux or macOS instead.'.format(system))
@@ -94,24 +94,31 @@ for fl in targets:
         extension = 'zip'
         filename = fl[:-len(extension)-1]
         final_name = os.path.basename('{}-{}.{}'.format(filename, distribution_version, extension))
-
-        shutil.copy(fl, os.path.join(directory_to_upload, final_name))
+        print('copy({}, {}'.format(fl, os.path.join(directory_to_upload, final_name)))
+        
+        # shutil.copy(fl, os.path.join(directory_to_upload, final_name))
     elif fl.endswith('tar.gz'):
         extension = 'tar.gz'
         filename = fl[:-len(extension)-1]
         final_name = os.path.basename('{}-{}.{}'.format(filename, distribution_version, extension))
-
-        shutil.copy(fl, os.path.join(directory_to_upload, final_name))
+        print('copy({}, {}'.format(fl, os.path.join(directory_to_upload, final_name)))
+        # shutil.copy(fl, os.path.join(directory_to_upload, final_name))
     else:
         raise ValueError('This file is neither a zip nor a tar.gz: {}'.format(fl))
+
+    print('pwd = {}'.format(os.getcwd()))
+    print('directory = {}'.format(directory_to_upload))
+
 try:
-    subprocess.call([
-        ghr,
-        '-u', github_organisation,
-        '-r', github_repository,
-        '-b', open('release_description.txt').read() if has_release_description else '',
-        '-delete', '-draft', github_tag,
-        directory_to_upload
-    ], env={'GITHUB_TOKEN': github_token})
+    # sp.call([
+    #     ghr,
+    #     '-u', github_organisation,
+    #     '-r', github_repository,
+    #     '-b', open('release_description.txt').read() if has_release_description else '',
+    #     '-delete', '-draft', github_tag,
+    #     directory_to_upload
+    # ], env={'GITHUB_TOKEN': github_token})
+    pass
 finally:
-    shutil.rmtree(directory_to_upload)
+    # shutil.rmtree(directory_to_upload)
+    pass

--- a/github/deploy.py
+++ b/github/deploy.py
@@ -88,17 +88,30 @@ def ghr_extract():
     return ghr
 
 
-def zip_repackage_with_version(original_archive, version):
-    extension = 'zip'
-    original_archive_basedir = original_archive[:-len(extension) - 1]
-    repackaged_archive_basedir = '{}-{}'.format(original_archive_basedir, version)
-    ZipFile(original_archive, 'r').extractall()
-    os.rename(original_archive_basedir, repackaged_archive_basedir)
-    repackaged_archive = shutil.make_archive(base_name=repackaged_archive_basedir, format=extension, base_dir=repackaged_archive_basedir)
-    shutil.copy(repackaged_archive, os.path.join(directory_to_upload, os.path.basename(repackaged_archive)))
+def zip_repackage_with_version(original_zipfile, version, directory_to_upload):
+    ext = 'zip'
+    original_zip_basedir = original_zipfile[:-len(ext) - 1]
+    repackaged_zip_basedir = '{}-{}'.format(original_zip_basedir, version)
+    repackaged_zipfile = repackaged_zip_basedir+'.zip'
+    with ZipFile(original_zipfile, 'r') as original_zip,\
+            ZipFile(repackaged_zipfile, 'w', compression=zipfile.ZIP_DEFLATED) as repackaged_zip:
+        for orig in sorted(original_zip.infolist()):
+            f = ''
+            name = './' + os.path.normpath(os.path.join(orig.filename))
+            if not orig.filename.endswith('/'):
+                f = original_zip.read(orig)
+            else:
+                name += '/'
+            repkg = zipfile.ZipInfo(name)
+            repkg.compress_type = zipfile.ZIP_DEFLATED
+            repkg.external_attr = orig.external_attr
+            repkg.date_time = orig.date_time
+            repackaged_zip.writestr(repkg, f)
+
+    shutil.copy(repackaged_zipfile, os.path.join(directory_to_upload, os.path.basename(repackaged_zipfile)))
 
 
-def tar_repackage_with_version(original_archive, version):
+def tar_repackage_with_version(original_archive, version, directory_to_upload):
     extension = 'tar.gz'
     original_archive_basedir = original_archive[:-len(extension) - 1]
     repackaged_archive_basedir = '{}-{}'.format(original_archive_basedir, version)
@@ -106,46 +119,52 @@ def tar_repackage_with_version(original_archive, version):
     os.rename(original_archive_basedir, repackaged_archive_basedir)
     repackaged_archive = shutil.make_archive(base_name=repackaged_archive_basedir, format='gztar', base_dir=repackaged_archive_basedir)
     shutil.copy(repackaged_archive, os.path.join(directory_to_upload, os.path.basename(repackaged_archive)))
+    shutil.rmtree(repackaged_archive_basedir)
 
 
-targets = [] if not "{targets}" else "{targets}".split(',')
-has_release_description = bool(int("{has_release_description}"))
+if __name__ == '__main__':
+    targets = [] if not "{targets}" else "{targets}".split(',')
+    has_release_description = bool(int("{has_release_description}"))
 
-github_token = get_github_token()
-properties = parse_deployment_properties('deployment.properties')
-github_organisation = properties['repo.github.organisation']
-github_repository = properties['repo.github.repository']
-ghr = ghr_extract()
+    github_token = get_github_token()
+    properties = parse_deployment_properties('deployment.properties')
+    github_organisation = properties['repo.github.organisation']
+    github_repository = properties['repo.github.repository']
+    ghr = ghr_extract()
 
-with open('VERSION') as version_file:
-    distribution_version = version_file.read().strip()
-    github_tag = 'v{}'.format(distribution_version)
+    with open('VERSION') as version_file:
+        distribution_version = version_file.read().strip()
+        github_tag = 'v{}'.format(distribution_version)
 
-directory_to_upload = tempfile.mkdtemp()
+    directory_to_upload = tempfile.mkdtemp()
 
-# TODO: ideally, this should be fixed in ghr itself
-# Currently it does not allow supplying empty folders
-# However, it also filters out folders inside the folder you supply
-# So if we have a folder within a folder, both conditions are
-# satisfied and we're able to proceed
-dummy_directory = tempfile.mkdtemp(dir=directory_to_upload)
+    # TODO: remove
+    print('pwd = {}'.format(os.getcwd()))
+    print('directory = {}'.format(directory_to_upload))
 
-for fl in targets:
-    if fl.endswith('zip'):
-        zip_repackage_with_version(fl, distribution_version)
-    elif fl.endswith('tar.gz'):
-        tar_repackage_with_version(fl, distribution_version)
-    else:
-        raise ValueError('This file is neither a zip nor a tar.gz: {}'.format(fl))
+    # TODO: ideally, this should be fixed in ghr itself
+    # Currently it does not allow supplying empty folders
+    # However, it also filters out folders inside the folder you supply
+    # So if we have a folder within a folder, both conditions are
+    # satisfied and we're able to proceed
+    dummy_directory = tempfile.mkdtemp(dir=directory_to_upload)
 
-try:
-    sp.call([
-        ghr,
-        '-u', github_organisation,
-        '-r', github_repository,
-        '-b', open('release_description.txt').read() if has_release_description else '',
-        '-delete', '-draft', github_tag,
-        directory_to_upload
-    ], env={'GITHUB_TOKEN': github_token})
-finally:
-    shutil.rmtree(directory_to_upload)
+    for fl in targets:
+        if fl.endswith('zip'):
+            zip_repackage_with_version(fl, distribution_version, directory_to_upload)
+        elif fl.endswith('tar.gz'):
+            tar_repackage_with_version(fl, distribution_version, directory_to_upload)
+        else:
+            raise ValueError('This file is neither a zip nor a tar.gz: {}'.format(fl))
+
+    try:
+        sp.call([
+            ghr,
+            '-u', github_organisation,
+            '-r', github_repository,
+            '-b', open('release_description.txt').read() if has_release_description else '',
+            '-delete', '-draft', github_tag,
+            directory_to_upload
+        ], env={'GITHUB_TOKEN': github_token})
+    finally:
+        shutil.rmtree(directory_to_upload)

--- a/github/rules.bzl
+++ b/github/rules.bzl
@@ -1,23 +1,18 @@
 def _deploy_github_impl(ctx):
     _deploy_script = ctx.actions.declare_file("_deploy.py")
 
-    files_to_deploy = []
-    files_to_deploy.extend(ctx.files.targets)
-    if ctx.file.target:
-        files_to_deploy.append(ctx.file.target)
-
     ctx.actions.expand_template(
         template = ctx.file._deploy_script,
         output = _deploy_script,
         substitutions = {
-            "{targets}": ",".join([file.short_path for file in files_to_deploy]),
+            "{archive}": ctx.file.archive.short_path,
             "{has_release_description}": str(int(bool(ctx.file.release_description)))
         }
     )
     files = [
         ctx.file.deployment_properties,
         ctx.file.version_file
-    ] + ctx.files._ghr + files_to_deploy
+    ] + ctx.files._ghr + [ctx.file.archive]
 
     symlinks = {
         "deployment.properties": ctx.file.deployment_properties
@@ -38,13 +33,9 @@ def _deploy_github_impl(ctx):
 
 deploy_github = rule(
     attrs = {
-        "target": attr.label(
+        "archive": attr.label(
             allow_single_file = [".zip"],
-            doc = "`distribution_zip` label to be deployed. Deprecated: use 'targets' attribute instead",
-        ),
-        "targets": attr.label_list(
-            allow_files = [".zip", ".tar.gz"],
-            doc = "`assemble_zip` or `assemble_targz` label to be deployed",
+            doc = "`assemble_versioned` label to be deployed.",
         ),
         "release_description": attr.label(
             allow_single_file = True,


### PR DESCRIPTION
## What is the goal of this PR?

### Adds version number to the distribution
Files that are deployed to Github used to look like this: `grakn-core-all-linux.tar.gz` and when extracted will be located in a directory `grakn-core-all-linux`.

With this PR they will look like this: `grakn-core-all-linux-1.5.0.tar.gz` and when extracted will be located in a directory `grakn-core-all-linux-1.5.0`.

## What are the changes implemented in this PR?

A new rule `assemble_versioned` is created. It outputs a distribution which contains the version number. Additionally, `checksum`, and `deploy_github` takes input from `assemble_versioned` rather than `assemble_zip` and `assemble_tar`