### PR TITLE
Make deployed .whl files universal (py2/py3)

### DIFF
--- a/pip/templates/deploy.sh
+++ b/pip/templates/deploy.sh
@@ -94,6 +94,11 @@ else
     sed -i.bak -e "s/-snapshot//g" setup.py && rm -f setup.py.bak
 fi
 
+cat > setup.cfg << EOF
+[bdist_wheel]
+universal = 1
+EOF
+
 # clean up previous distribution files
 rm -fv dist/*
 python setup.py sdist


### PR DESCRIPTION
## What is the goal of this PR?

Previously, `deploy_pip` would've generated `-py2.whl` files. We want to have 'universal' wheel files available for both python2 and python3

## What are the changes implemented in this PR?

Added `setup.cfg` to configure `wheel`. from [doc ref](https://wheel.readthedocs.io/en/stable/user_guide.html#building-wheels):

>If your project contains no C extensions and is expected to work on both Python 2 and 3, you will want to tell wheel to produce universal wheels by adding this to your setup.cfg file: …