### PR TITLE
deploy_github - the release should set the commit id properly

### DIFF
--- a/github/deploy.py
+++ b/github/deploy.py
@@ -110,6 +110,7 @@ try:
         '-u', github_organisation,
         '-r', github_repository,
         '-b', open('release_description.txt').read() if has_release_description else '',
+        '-c', os.environ('CIRCLE_SHA1'),
         '-delete', '-draft', github_tag, # TODO: tag must reference the current commit
         directory_to_upload
     ], env={'GITHUB_TOKEN': github_token})


### PR DESCRIPTION
## What is the goal of this PR?

Closes https://github.com/graknlabs/bazel-distribution/issues/107

`deploy_github` creates a Github draft which points to the latest `master` instead of the commit id from which the release is made from.

This behavior is incorrect and in this PR, we changed the behavior where `deploy-github` must be supplied with "target commit id":
```
bazel run //:deploy-github -- <target-commit-id>
```

## What are the changes implemented in this PR?
Accepts "target commit id" as an argument and supply it to `ghr` so that it creates a draft that correctly points to the right commit id instead of latest `master`

