### PR TITLE
Replace {pom_version} with actual version

### DIFF
--- a/maven/_pom_replace_version.py
+++ b/maven/_pom_replace_version.py
@@ -19,5 +19,6 @@ with open(preprocessed_template_path, 'r') as template_file, \
         pom = pom.replace(workspace, refs['commits'][workspace])
     for workspace in refs['tags']:
         pom = pom.replace(workspace, refs['tags'][workspace])
+    pom = pom.replace('{pom_version}', version)
 
     pom_file.write(pom)


### PR DESCRIPTION
## What is the goal of this PR?

Fixes #113

## What are the changes implemented in this PR?

JARs built by `assemble_maven` are now versioned properly