### PR TITLE
Implement *_packer rules

### DIFF
--- a/packer/dependencies.bzl
+++ b/packer/dependencies.bzl
@@ -18,7 +18,7 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-def deploy_gcp_dependencies():
+def deploy_packer_dependencies():
     http_archive(
          name = "packer_osx",
          url = "https://releases.hashicorp.com/packer/1.4.0/packer_1.4.0_darwin_amd64.zip",

--- a/packer/dependencies.bzl
+++ b/packer/dependencies.bzl
@@ -1,21 +1,3 @@
-#
-# GRAKN.AI - THE KNOWLEDGE GRAPH
-# Copyright (C) 2018 Grakn Labs Ltd
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def deploy_packer_dependencies():

--- a/packer/dependencies.bzl
+++ b/packer/dependencies.bzl
@@ -1,0 +1,34 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+def deploy_gcp_dependencies():
+    http_archive(
+         name = "packer_osx",
+         url = "https://releases.hashicorp.com/packer/1.4.0/packer_1.4.0_darwin_amd64.zip",
+         sha256 = "475a2a63d37c5bbd27a4b836ffb1ac85d1288f4d55caf04fde3e31ca8e289773",
+         build_file_content = 'exports_files(["packer"])'
+    )
+
+    http_archive(
+         name = "packer_linux",
+         url = "https://releases.hashicorp.com/packer/1.4.0/packer_1.4.0_linux_amd64.zip",
+         sha256 = "7505e11ce05103f6c170c6d491efe3faea1fb49544db0278377160ffb72721e4",
+         build_file_content = 'exports_files(["packer"])'
+    )

--- a/packer/rules.bzl
+++ b/packer/rules.bzl
@@ -1,0 +1,56 @@
+load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
+
+def assemble_packer(name,
+                    config,
+                    files = {}):
+    _files = {
+        config: "config.json"
+    }
+    for k, v in files.items():
+        _files[k] = "files/" + v
+    pkg_tar(
+        name = name,
+        extension = "packer.tar",
+        files = _files
+    )
+
+def _deploy_packer_impl(ctx):
+    deployment_script = ctx.actions.declare_file("deploy_packer.py")
+
+    ctx.actions.expand_template(
+        template = ctx.file._deployment_script_template,
+        output = deployment_script,
+        substitutions = {
+            "{packer_osx_binary}": ctx.files._packer[0].path,
+            "{packer_linux_binary}": ctx.files._packer[1].path,
+            "{target_tar}": ctx.file.target.short_path
+        },
+        is_executable = True
+    )
+
+    return DefaultInfo(
+        executable = deployment_script,
+        runfiles = ctx.runfiles(files = [ctx.file.target] + ctx.files._packer)
+    )
+
+deploy_packer = rule(
+    attrs = {
+        "target": attr.label(
+            mandatory = False,
+            allow_single_file = [".packer.tar"],
+            doc = "Distribution to be deployed.",
+        ),
+        "_deployment_script_template": attr.label(
+            allow_single_file = True,
+            default = "@graknlabs_bazel_distribution//packer/templates:deploy_packer.py",
+        ),
+        "_packer": attr.label_list(
+            allow_files = True,
+            default = ["@packer_osx//:packer", "@packer_linux//:packer"]
+        ),
+    },
+    executable = True,
+    implementation = _deploy_packer_impl
+)
+
+

--- a/packer/rules.bzl
+++ b/packer/rules.bzl
@@ -52,5 +52,3 @@ deploy_packer = rule(
     executable = True,
     implementation = _deploy_packer_impl
 )
-
-

--- a/packer/templates/BUILD
+++ b/packer/templates/BUILD
@@ -1,19 +1,1 @@
-#
-# GRAKN.AI - THE KNOWLEDGE GRAPH
-# Copyright (C) 2018 Grakn Labs Ltd
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <https://www.gnu.org/licenses/>.
-#
-
 exports_files(["deploy_packer.py"])

--- a/packer/templates/BUILD
+++ b/packer/templates/BUILD
@@ -1,0 +1,19 @@
+#
+# GRAKN.AI - THE KNOWLEDGE GRAPH
+# Copyright (C) 2018 Grakn Labs Ltd
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as
+# published by the Free Software Foundation, either version 3 of the
+# License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+
+exports_files(["deploy_packer.py"])

--- a/packer/templates/deploy_packer.py
+++ b/packer/templates/deploy_packer.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python
+
+import os
+import tempfile
+import tarfile
+import platform
+import subprocess as sp
+import shutil
+
+PACKER_BINARIES = {
+    "Darwin": os.path.abspath("{packer_osx_binary}"),
+    "Linux": os.path.abspath("{packer_linux_binary}"),
+}
+
+system = platform.system()
+
+if system not in PACKER_BINARIES:
+    raise ValueError('Packer does not have binary for {}'.format(system))
+
+TARGET_TAR_LOCATION = "{target_tar}"
+
+target_temp_dir = tempfile.mkdtemp('deploy_packer')
+with tarfile.open(TARGET_TAR_LOCATION, 'r') as target_tar:
+    target_tar.extractall(target_temp_dir)
+
+sp.check_call([
+    PACKER_BINARIES[system],
+    'build',
+    'config.json'
+], cwd=target_temp_dir)
+
+shutil.rmtree(target_temp_dir)


### PR DESCRIPTION
## What is the goal of this PR?

Have `assemble_packer` and `deploy_packer` rules useful in deployment to cloud providers, such as AWS and GCP.

The rule is essentially a Bazelised version of Hashicorp's [Packer](packer.io).

## What are the changes implemented in this PR?

Implemented `assemble_packer` macro (based on `pkg_tar` provided by `bazel`) and `deploy_packer` rule

Sample usage:

```
assemble_packer(
    name = "assemble-gcp",
    config = ":gcp.json",
    files = {
        "//:assemble-linux-targz": "grakn-core-all-linux.tar.gz",
        …
    }
)

deploy_packer(
    name = "deploy-gcp",
    target = ":assemble-gcp",
)
```