### PR TITLE
Make it possible to have multiple deploy_packer targets in same BUILD file

### DIFF
--- a/packer/rules.bzl
+++ b/packer/rules.bzl
@@ -15,7 +15,7 @@ def assemble_packer(name,
     )
 
 def _deploy_packer_impl(ctx):
-    deployment_script = ctx.actions.declare_file("deploy_packer.py")
+    deployment_script = ctx.actions.declare_file("{}_deploy_packer.py".format(ctx.attr.target.label.name))
 
     ctx.actions.expand_template(
         template = ctx.file._deployment_script_template,


### PR DESCRIPTION
## What is the goal of this PR?

Make it possible to have multiple deploy_packer targets in same BUILD file. Right now, if we have multiple `deploy_packer` targets Bazel will fail to build with the following error:

```
ERROR: file 'deploy_packer.py.runfiles.SOURCES' is generated by these conflicting actions:
Label: //:deploy-aws, //:deploy-gcp
```

## What are the changes implemented in this PR?

Use unique name for `ctx.actions.declare_file` based on target's label name