### PR TITLE
deploy_github rule should use bazel for unpacking

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,1 +1,4 @@
 workspace(name="graknlabs_bazel_distribution")
+
+load("//github:dependencies.bzl", "github_dependencies_for_deployment")
+github_dependencies_for_deployment()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,13 +1,1 @@
 workspace(name="graknlabs_bazel_distribution")
-
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
-
-http_file(
-    name = "ghr_osx_zip",
-    urls = ["https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_darwin_amd64.zip"]
-)
-
-http_file(
-    name = "ghr_linux_tar",
-    urls = ["https://github.com/tcnksm/ghr/releases/download/v0.12.0/ghr_v0.12.0_linux_amd64.tar.gz"]
-)

--- a/github/dependencies.bzl
+++ b/github/dependencies.bzl
@@ -16,14 +16,18 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 #
 
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 def github_dependencies_for_deployment():
-    http_file(
+    http_archive(
         name = "ghr_osx_zip",
-        urls = ["https://github.com/tcnksm/ghr/releases/download/v0.10.2/ghr_v0.10.2_darwin_386.zip"]
+        urls = ["https://github.com/tcnksm/ghr/releases/download/v0.10.2/ghr_v0.10.2_darwin_386.zip"],
+        sha256 = "453fa48b6837f36ff32ccfe3f4f6ad7c131952c87370c38d18f83b6614c00bb3",
+        build_file_content = 'exports_files(["ghr"])'
     )
-    http_file(
+    http_archive(
         name = "ghr_linux_tar",
-        urls = ["https://github.com/tcnksm/ghr/releases/download/v0.10.2/ghr_v0.10.2_linux_386.tar.gz"]
+        urls = ["https://github.com/tcnksm/ghr/releases/download/v0.10.2/ghr_v0.10.2_linux_386.tar.gz"],
+        sha256 = "214ec68b48516d2d2e627fbf4da1a4cc84d182de5945c63c07aea53c2b8cc166",
+        build_file_content = 'exports_files(["ghr"])'
     )

--- a/github/dependencies.bzl
+++ b/github/dependencies.bzl
@@ -23,11 +23,13 @@ def github_dependencies_for_deployment():
         name = "ghr_osx_zip",
         urls = ["https://github.com/tcnksm/ghr/releases/download/v0.10.2/ghr_v0.10.2_darwin_386.zip"],
         sha256 = "453fa48b6837f36ff32ccfe3f4f6ad7c131952c87370c38d18f83b6614c00bb3",
+        strip_prefix = "ghr_v0.10.2_darwin_386",
         build_file_content = 'exports_files(["ghr"])'
     )
     http_archive(
         name = "ghr_linux_tar",
         urls = ["https://github.com/tcnksm/ghr/releases/download/v0.10.2/ghr_v0.10.2_linux_386.tar.gz"],
         sha256 = "214ec68b48516d2d2e627fbf4da1a4cc84d182de5945c63c07aea53c2b8cc166",
+        strip_prefix = "ghr_v0.10.2_linux_386",
         build_file_content = 'exports_files(["ghr"])'
     )

--- a/github/rules.bzl
+++ b/github/rules.bzl
@@ -7,7 +7,9 @@ def _deploy_github_impl(ctx):
         output = _deploy_script,
         substitutions = {
             "{archive}": ctx.file.archive.short_path if (ctx.file.archive!=None) else "",
-            "{has_release_description}": str(int(bool(ctx.file.release_description)))
+            "{has_release_description}": str(int(bool(ctx.file.release_description))),
+            "{ghr_osx_binary}": ctx.files._ghr[0].path,
+            "{ghr_linux_binary}": ctx.files._ghr[1].path,
         }
     )
     files = [
@@ -61,7 +63,7 @@ deploy_github = rule(
             default = "//github:deploy.py",
         ),
         "_ghr": attr.label_list(
-            default = ["@ghr_osx_zip//file:file", "@ghr_linux_tar//file:file"]
+            default = ["@ghr_osx_zip//:ghr", "@ghr_linux_tar//:ghr"]
         )
     },
     implementation = _deploy_github_impl,

--- a/github/rules.bzl
+++ b/github/rules.bzl
@@ -63,6 +63,7 @@ deploy_github = rule(
             default = "//github:deploy.py",
         ),
         "_ghr": attr.label_list(
+            allow_files = True,
             default = ["@ghr_osx_zip//:ghr", "@ghr_linux_tar//:ghr"]
         )
     },


### PR DESCRIPTION
## What is the goal of this PR?

Simplify `deploy_github`

## What are the changes implemented in this PR?

Utilize `bazel`'s `http_archive` to unpack `ghr` instead of doing it in Python