### PR TITLE
java_deps: allow inclusion of libraries with duplicate names

### DIFF
--- a/common/rules.bzl
+++ b/common/rules.bzl
@@ -92,18 +92,14 @@ _transitive_collect_maven_coordinate = aspect(
 def _java_deps_impl(ctx):
     names = {}
     files = []
-    filenames = []
 
     mapping = ctx.attr.target[TransitiveJarToMavenCoordinatesMapping].mapping
 
     for file in ctx.attr.target.data_runfiles.files.to_list():
-        if file.basename in filenames:
-            continue # do not pack JARs with same name
         if file.extension == 'jar' and not file.path.startswith(LOCAL_JDK_PREFIX):
-            filename = mapping.get(file.path, file.basename).replace('.', '-').replace(':', '-')
+            filename = file.owner.package.replace('/', '-') + '__' + mapping.get(file.path, file.basename).replace('.', '-').replace(':', '-')
             names[file.path] = ctx.attr.java_deps_root + filename + ".jar"
             files.append(file)
-            filenames.append(file.basename)
 
     jars_mapping = ctx.actions.declare_file("{}_jars.mapping".format(ctx.attr.target.label.name))
 


### PR DESCRIPTION
## What is the goal of this PR?

Fixes #111 

## What are the changes implemented in this PR?

- Remove check for duplicated library file names
- Prefix every library in the archive with its owner's package name

Considering the example similar to one in the issue:

```
java_library(
    name = "xserver",
    runtime_deps = [
        "//daemon:library",
        "//server:library",
    ]
)

java_deps(
    name = "xserver-deps",
    target = ":xserver",
    java_deps_root = "server/services/lib/",
    version_file = "//:VERSION",
    visibility = ["//:__pkg__"]
)
```

these libraries with duplicate library file names will be placed in the archive:
```
-r-xr-xr-x  0 vmax   wheel    5440 Jan  1  1970 server/services/lib/daemon__liblibrary-jar.jar
-r-xr-xr-x  0 vmax   wheel   31305 Jan  1  1970 server/services/lib/server__liblibrary-jar.jar
```