### PR TITLE
assemble_maven and deploy_maven should produce and upload Maven artifact with the correct pom files

### DIFF
--- a/maven/_pom_replace_version.py
+++ b/maven/_pom_replace_version.py
@@ -38,6 +38,5 @@ with open(preprocessed_template_path, 'r') as template_file, \
         pom = pom.replace(workspace, refs['commits'][workspace])
     for workspace in refs['tags']:
         pom = pom.replace(workspace, refs['tags'][workspace])
-    pom = pom.replace('{pom_version}', version)
 
     pom_file.write(pom)

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -29,7 +29,6 @@ import re
 import subprocess as sp
 import sys
 import tempfile
-
 import zipfile
 
 
@@ -46,6 +45,7 @@ class ZipFile(zipfile.ZipFile):
         attr = member.external_attr >> 16
         os.chmod(ret_val, attr)
         return ret_val
+
 
 def parse_deployment_properties(fn):
     deployment_properties = {}


### PR DESCRIPTION
## What is the goal of this PR?

There are two `pom.xml`s that got produced, the actual `pom.xml` file and an additional copy which is embedded inside the JAR which servers as metadata.

During the assembly step, these two files should just contain a version placeholder `{pom_version}` rather than the actual version number. The actual version number would only be added during the deployment step.