### PR TITLE
Specify default condition so build works on Windows too

### DIFF
--- a/rpm/rules.bzl
+++ b/rpm/rules.bzl
@@ -77,6 +77,7 @@ def assemble_rpm(name,
         rpmbuild_path = select({
             ":linux_build": "/usr/bin/rpmbuild",
             ":osx_build": "/usr/local/bin/rpmbuild",
+            "//conditions:default": ""
         })
     )
     tag = "rpm_package_name={}".format(spec_file.split(':')[-1].replace('.spec', ''))


### PR DESCRIPTION
## What is the goal of this PR?

Fix #126

## What are the changes implemented in this PR?

Specifying default condition allows build to succeed on Windows.