### PR TITLE
Add assemble_gcp rule that encapsulates generating config

### DIFF
--- a/common/generate_json_config.bzl
+++ b/common/generate_json_config.bzl
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+def _generate_json_config_impl(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file.template,
+        output = ctx.outputs.config,
+        substitutions = ctx.attr.substitutions
+    )
+
+generate_json_config = rule(
+    attrs = {
+        "template": attr.label(
+            allow_single_file = [".json"]
+        ),
+        "substitutions": attr.string_dict()
+    },
+    implementation = _generate_json_config_impl,
+    outputs = {
+        "config": "%{name}.json"
+    }
+)

--- a/gcp/BUILD
+++ b/gcp/BUILD
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+exports_files(["packer.template.json"])

--- a/gcp/packer.template.json
+++ b/gcp/packer.template.json
@@ -28,7 +28,7 @@
     },
     {
       "type": "shell",
-      "inline": [ "sudo /tmp/deployment/install.sh" ]
+      "inline": [ "sudo /tmp/deployment/{install}" ]
     }
   ]
 }

--- a/gcp/packer.template.json
+++ b/gcp/packer.template.json
@@ -1,0 +1,34 @@
+{
+  "variables": {
+    "gcp_account_file": "{{env `DEPLOY_PACKER_GCP_ACCOUNT_FILE`}}",
+    "version": "{{env `DEPLOY_PACKER_VERSION`}}"
+  },
+  "builders": [
+    {
+      "type": "googlecompute",
+      "account_file": "{{user `gcp_account_file`}}",
+      "project_id": "{project_id}",
+      "source_image_family": "ubuntu-1604-lts",
+      "zone": "{zone}",
+      "ssh_username": "ubuntu",
+      "image_name": "{image_name}",
+      "image_licenses": ["{image_licenses}"]
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [ "mkdir /tmp/deployment" ]
+    },
+    {
+      "type": "file",
+      "source": "files/",
+      "destination": "/tmp/deployment/"
+    },
+    {
+      "type": "shell",
+      "inline": [ "sudo /tmp/deployment/install.sh" ]
+    }
+  ]
+}

--- a/gcp/rules.bzl
+++ b/gcp/rules.bzl
@@ -23,10 +23,12 @@ load("//common:generate_json_config.bzl", "generate_json_config")
 
 def assemble_gcp(name,
                  project_id,
+                 install,
                  zone,
                  image_name,
                  image_licenses,
                  files):
+    install_fn = Label(install).name
     generated_config_target_name = name + "__do_not_reference_config"
     generate_json_config(
         name = generated_config_target_name,
@@ -35,9 +37,11 @@ def assemble_gcp(name,
             "{project_id}": project_id,
             "{zone}": zone,
             "{image_name}": image_name,
-            "{image_licenses}": image_licenses
+            "{image_licenses}": image_licenses,
+            "{install}": install_fn
         }
     )
+    files[install] = install_fn
     assemble_packer(
         name = name,
         config = generated_config_target_name,

--- a/gcp/rules.bzl
+++ b/gcp/rules.bzl
@@ -1,0 +1,45 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+load("//packer:rules.bzl", "assemble_packer")
+load("//common:generate_json_config.bzl", "generate_json_config")
+
+
+def assemble_gcp(name,
+                 project_id,
+                 zone,
+                 image_name,
+                 image_licenses,
+                 files):
+    generated_config_target_name = name + "__do_not_reference_config"
+    generate_json_config(
+        name = generated_config_target_name,
+        template = "@graknlabs_bazel_distribution//gcp:packer.template.json",
+        substitutions = {
+            "{project_id}": project_id,
+            "{zone}": zone,
+            "{image_name}": image_name,
+            "{image_licenses}": image_licenses
+        }
+    )
+    assemble_packer(
+        name = name,
+        config = generated_config_target_name,
+        files = files
+    )


### PR DESCRIPTION
## What is the goal of this PR?

First part of making AWS/GCP rules more user-friendly (issue #124)

## What are the changes implemented in this PR?

- Adds `generate_json_config` rule which allows to substitute values in template
- Adds `assemble_gcp` which generates config and calls `assemble_packer`. Sample usage:

```
assemble_gcp(
    name = "assemble-gcp-snapshot",
    files = GCP_FILES,
    install = "//deployment/deploy-gcp-image/files:install.sh",
    project_id = "grakn-dev",
    zone = "europe-west1-b",
    image_name = "grakn-kgms-snapshot-{{user `version`}}",
    image_licenses = 'projects/grakn-public/global/licenses/grakn-kgms-premium'
)
```