### PR TITLE
Add assemble_aws rule that encapsulates generating config

### DIFF
--- a/aws/BUILD
+++ b/aws/BUILD
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+exports_files(["packer.template.json"])

--- a/aws/packer.template.json
+++ b/aws/packer.template.json
@@ -1,0 +1,44 @@
+{
+  "variables": {
+    "access_key": "{{env `DEPLOY_PACKER_AWS_ACCESS_KEY`}}",
+    "secret_key": "{{env `DEPLOY_PACKER_AWS_SECRET_KEY`}}",
+    "version": "{{env `DEPLOY_PACKER_VERSION`}}"
+  },
+  "builders": [{
+    "type": "amazon-ebs",
+    "region": "{region}",
+    "source_ami_filter": {
+      "filters": {
+        "virtualization-type": "hvm",
+        "name": "ubuntu/images/*ubuntu-xenial-16.04-amd64-server-*",
+        "root-device-type": "ebs"
+      },
+      "owners": ["099720109477"],
+      "most_recent": true
+    },
+    "instance_type": "t2.medium",
+    "ssh_username": "ubuntu",
+    "ami_name": "{ami_name}",
+    "access_key": "{{user `access_key`}}",
+    "secret_key": "{{user `secret_key`}}",
+    "force_deregister": "true",
+    "force_delete_snapshot": "true"
+  }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [ "mkdir /tmp/deployment" ]
+    },
+    {
+      "type": "file",
+      "source": "files/",
+      "destination": "/tmp/deployment/"
+    },
+    {
+      "type": "shell",
+      "inline": ["sudo /tmp/deployment/{install}"]
+    }
+  ]
+}

--- a/aws/rules.bzl
+++ b/aws/rules.bzl
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+load("//packer:rules.bzl", "assemble_packer")
+load("//common:generate_json_config.bzl", "generate_json_config")
+
+def assemble_aws(name,
+                 ami_name,
+                 install,
+                 region,
+                 files):
+    install_fn = Label(install).name
+    generated_config_target_name = name + "__do_not_reference_config"
+    generate_json_config(
+        name = generated_config_target_name,
+        template = "@graknlabs_bazel_distribution//aws:packer.template.json",
+        substitutions = {
+            "{ami_name}": ami_name, # grakn-kgms-{{user `version`}}
+            "{install}": install_fn,
+            "{region}": region
+        }
+    )
+    files[install] = install_fn
+    assemble_packer(
+        name = name,
+        config = generated_config_target_name,
+        files = files
+    )

--- a/aws/rules.bzl
+++ b/aws/rules.bzl
@@ -31,7 +31,7 @@ def assemble_aws(name,
         name = generated_config_target_name,
         template = "@graknlabs_bazel_distribution//aws:packer.template.json",
         substitutions = {
-            "{ami_name}": ami_name, # grakn-kgms-{{user `version`}}
+            "{ami_name}": ami_name,
             "{install}": install_fn,
             "{region}": region
         }


### PR DESCRIPTION
## What is the goal of this PR?

Second part of making AWS/GCP rules more user-friendly (issue #124)

## What are the changes implemented in this PR?

- Adds `assemble_aws` which generates config and calls `assemble_packer`. Sample usage:

```
assemble_aws(
    name = "assemble-aws-snapshot",
    ami_name = "grakn-kgms-snapshot-{{user `version`}}",
    install = "//deployment/deploy-aws-image/files:install.py",
    region = "us-east-1",
    files = AWS_FILES
)
```