### PR TITLE
Maven deployment script should properly concatenate URLs

### DIFF
--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -23,13 +23,14 @@ from __future__ import print_function
 from xml.etree import ElementTree
 
 import hashlib
-import operator
 import os
 import re
 import subprocess as sp
 import sys
 import tempfile
 import zipfile
+from urlparse import urljoin
+
 
 def parse_deployment_properties(fn):
     deployment_properties = {}
@@ -82,7 +83,7 @@ def upload(url, username, password, local_fn, remote_fn):
         '--write-out', '%{http_code}',
         '-u', '{}:{}'.format(username, password),
         '--upload-file', local_fn,
-        url + remote_fn
+        urljoin(url, remote_fn)
     ]).strip()
 
     if upload_status_code != '201':

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -29,7 +29,7 @@ import subprocess as sp
 import sys
 import tempfile
 import zipfile
-from urlparse import urljoin
+from posixpath import join as urljoin
 
 
 def parse_deployment_properties(fn):


### PR DESCRIPTION
## What is the goal of this PR?

Fix #137
Previously, Maven repo URLs in `deployment.properties` were expected to have trailing slash. This PR removes such a need and supports both having and not having trailing slashes.

## What are the changes implemented in this PR?

- Use `posixpath.join` as a proper way of concatenating URLs
- Remove unused import of `operator`
