### PR TITLE
Option to force Maven naming scheme for java_deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,7 +734,7 @@ generate_json_config(<a href="#generate_json_config-name">name</a>, <a href="#ge
 ## java_deps
 
 <pre>
-java_deps(<a href="#java_deps-name">name</a>, <a href="#java_deps-java_deps_root">java_deps_root</a>, <a href="#java_deps-target">target</a>, <a href="#java_deps-version_file">version_file</a>)
+java_deps(<a href="#java_deps-name">name</a>, <a href="#java_deps-java_deps_root">java_deps_root</a>, <a href="#java_deps-maven_name">maven_name</a>, <a href="#java_deps-target">target</a>, <a href="#java_deps-version_file">version_file</a>)
 </pre>
 
 
@@ -762,6 +762,15 @@ java_deps(<a href="#java_deps-name">name</a>, <a href="#java_deps-java_deps_root
         String; optional
         <p>
           Folder inside archive to put JARs into
+        </p>
+      </td>
+    </tr>
+    <tr id="java_deps-maven_name">
+      <td><code>maven_name</code></td>
+      <td>
+        Boolean; optional
+        <p>
+          Name JAR files inside archive based on Maven coordinates
         </p>
       </td>
     </tr>

--- a/common/java_deps.bzl
+++ b/common/java_deps.bzl
@@ -117,6 +117,8 @@ def _java_deps_impl(ctx):
         if file.basename in filenames:
             continue # do not pack JARs with same name
         if file.extension == 'jar' and not file.path.startswith(LOCAL_JDK_PREFIX):
+            if ctx.attr.maven_name and file.path not in mapping:
+                fail("{} does not have associated Maven coordinate".format(file.owner))
             filename = mapping.get(file.path, file.basename).replace('.', '-').replace(':', '-')
             names[file.path] = ctx.attr.java_deps_root + filename + ".jar"
             files.append(file)
@@ -154,6 +156,10 @@ java_deps = rule(
         "version_file": attr.label(
             allow_single_file = True,
             mandatory = True
+        ),
+        "maven_name": attr.bool(
+            doc = "Name JAR files inside archive based on Maven coordinates",
+            default = False,
         ),
         "_java_deps_builder": attr.label(
             default = "//common:java_deps",


### PR DESCRIPTION
## What is the goal of this PR?

Fix #111
In order to help with duplicate names issue, a naming scheme based on Maven coordinates is going to be adopted. To help with its adoption, an attribute that *forces* all artifacts to have Maven coordinates is introduced.

## What are the changes implemented in this PR?

- Add `maven_name` attribute to `java_deps` rule. By default it's `False`, not changing workflow of existing users.
- If `maven_name` attribute is set to True, `fail(…)`  and aspect did not attach maven coordinate to target, fail loudly
