### PR TITLE
Support custom title in deploy_github rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ deploy_brew(<a href="#deploy_brew-name">name</a>, <a href="#deploy_brew-checksum
 ## deploy_github
 
 <pre>
-deploy_github(<a href="#deploy_github-name">name</a>, <a href="#deploy_github-archive">archive</a>, <a href="#deploy_github-deployment_properties">deployment_properties</a>, <a href="#deploy_github-release_description">release_description</a>, <a href="#deploy_github-version_file">version_file</a>)
+deploy_github(<a href="#deploy_github-name">name</a>, <a href="#deploy_github-archive">archive</a>, <a href="#deploy_github-deployment_properties">deployment_properties</a>, <a href="#deploy_github-release_description">release_description</a>, <a href="#deploy_github-title">title</a>, <a href="#deploy_github-title_append_version">title_append_version</a>, <a href="#deploy_github-version_file">version_file</a>)
 </pre>
 
 
@@ -332,6 +332,24 @@ deploy_github(<a href="#deploy_github-name">name</a>, <a href="#deploy_github-ar
         <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
         <p>
           Description of GitHub release
+        </p>
+      </td>
+    </tr>
+    <tr id="deploy_github-title">
+      <td><code>title</code></td>
+      <td>
+        String; optional
+        <p>
+          Title of GitHub release
+        </p>
+      </td>
+    </tr>
+    <tr id="deploy_github-title_append_version">
+      <td><code>title_append_version</code></td>
+      <td>
+        Boolean; optional
+        <p>
+          Append version to GitHub release title
         </p>
       </td>
     </tr>

--- a/github/dependencies.bzl
+++ b/github/dependencies.bzl
@@ -22,15 +22,15 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 def github_dependencies_for_deployment():
     http_archive(
         name = "ghr_osx_zip",
-        urls = ["https://github.com/tcnksm/ghr/releases/download/v0.10.2/ghr_v0.10.2_darwin_386.zip"],
-        sha256 = "453fa48b6837f36ff32ccfe3f4f6ad7c131952c87370c38d18f83b6614c00bb3",
-        strip_prefix = "ghr_v0.10.2_darwin_386",
+        urls = ["https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_darwin_amd64.zip"],
+        sha256 = "b5d1379e519fc3b795f3b81e5404d427e0abd8837d9e249f483a72f999dd4f47",
+        strip_prefix = "ghr_v0.12.1_darwin_amd64",
         build_file_content = 'exports_files(["ghr"])'
     )
     http_archive(
         name = "ghr_linux_tar",
-        urls = ["https://github.com/tcnksm/ghr/releases/download/v0.10.2/ghr_v0.10.2_linux_386.tar.gz"],
-        sha256 = "214ec68b48516d2d2e627fbf4da1a4cc84d182de5945c63c07aea53c2b8cc166",
-        strip_prefix = "ghr_v0.10.2_linux_386",
+        urls = ["https://github.com/tcnksm/ghr/releases/download/v0.12.1/ghr_v0.12.1_linux_amd64.tar.gz"],
+        sha256 = "471c2eb1aee20dedffd00254f6c445abb5eb7d479bcae32c4210fdcf036b2dce",
+        strip_prefix = "ghr_v0.12.1_linux_amd64",
         build_file_content = 'exports_files(["ghr"])'
     )

--- a/github/deploy.py
+++ b/github/deploy.py
@@ -81,6 +81,10 @@ if args.archive and not os.path.isfile(args.archive):
     raise Exception("argument supplied in --archive is not a file")
 
 archive = "{archive}" or args.archive
+
+title = "{release_title}"
+title_append_version = bool(int("{title_append_version}"))
+
 has_release_description = bool(int("{has_release_description}"))
 github_token = os.getenv('DEPLOY_GITHUB_TOKEN')
 target_commit_id = args.commit_id
@@ -91,6 +95,9 @@ ghr = GHR_BINARIES[system]
 
 with open('VERSION') as version_file:
     github_tag = version_file.read().strip()
+
+if title and title_append_version:
+    title += " {}".format(github_tag)
 
 directory_to_upload = tempfile.mkdtemp()
 
@@ -109,6 +116,7 @@ try:
         ghr,
         '-u', github_organisation,
         '-r', github_repository,
+        '-n', title,
         '-b', open('release_description.txt').read() if has_release_description else '',
         '-c', target_commit_id,
         '-delete', '-draft', github_tag,  # TODO: tag must reference the current commit

--- a/github/rules.bzl
+++ b/github/rules.bzl
@@ -28,6 +28,8 @@ def _deploy_github_impl(ctx):
             "{has_release_description}": str(int(bool(ctx.file.release_description))),
             "{ghr_osx_binary}": ctx.files._ghr[0].path,
             "{ghr_linux_binary}": ctx.files._ghr[1].path,
+            "{release_title}": ctx.attr.title or "",
+            "{title_append_version}": str(int(bool(ctx.attr.title_append_version)))
         }
     )
     files = [
@@ -61,6 +63,14 @@ deploy_github = rule(
             mandatory = False,
             allow_single_file = [".zip"],
             doc = "`assemble_versioned` label to be deployed.",
+        ),
+        "title": attr.string(
+            mandatory = False,
+            doc = "Title of GitHub release"
+        ),
+        "title_append_version": attr.bool(
+            default = False,
+            doc = "Append version to GitHub release title"
         ),
         "release_description": attr.label(
             allow_single_file = True,


### PR DESCRIPTION
## What is the goal of this PR?

Fix #103
This PR allows supplying custom `title` (optionally appending version) to `deploy_github` targets which allows to further automate release creation.

## What are the changes implemented in this PR?

- Bump `ghr` to `0.12.1` to support `-n` argument (release title)
- Add optional `title` and `title_append_version` arguments to `deploy_github` rule