### PR TITLE
Only define parse_deployment_properties once

### DIFF
--- a/brew/rules.bzl
+++ b/brew/rules.bzl
@@ -34,13 +34,15 @@ def _deploy_brew_impl(ctx):
     files = [
         ctx.file.deployment_properties,
         ctx.file.formula,
-        ctx.file.version_file
+        ctx.file.version_file,
+        ctx.file._common_py
     ]
 
     symlinks = {
         'deployment.properties': ctx.file.deployment_properties,
         'formula': ctx.file.formula,
-        'VERSION': ctx.file.version_file
+        'VERSION': ctx.file.version_file,
+        'common.py': ctx.file._common_py,
     }
 
     if ctx.file.checksum:
@@ -89,6 +91,10 @@ deploy_brew = rule(
             allow_single_file = True,
             default = "//brew/templates:deploy.py"
         ),
+        "_common_py": attr.label(
+            allow_single_file = True,
+            default = "//common:common.py"
+        )
     },
     executable = True,
     outputs = {

--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -27,18 +27,11 @@ import sys
 import tempfile
 import urllib
 
-
-def parse_deployment_properties(fn):
-    deployment_properties = {}
-    with open(fn) as deployment_properties_file:
-        for line in deployment_properties_file.readlines():
-            if line.startswith('#'):
-                # skip comments
-                pass
-            elif '=' in line:
-                k, v = line.split('=')
-                deployment_properties[k] = v.strip()
-    return deployment_properties
+# usual importing is not possible because
+# this script and module with common functions
+# are at different directory levels in sandbox
+from runpy import run_path
+parse_deployment_properties = run_path('common.py')['parse_deployment_properties']
 
 
 def get_distribution_url_from_formula(content):

--- a/common/BUILD
+++ b/common/BUILD
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-exports_files(["archiver.py"])
+exports_files(["archiver.py", "common.py"])
 
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
@@ -48,7 +48,8 @@ py_binary(
 
 py_library(
     name = "common",
-    srcs = ["common.py"]
+    srcs = ["common.py"],
+    visibility = ["//visibility:public"]
 )
 
 py_binary(

--- a/common/common.py
+++ b/common/common.py
@@ -76,3 +76,16 @@ def tar_repackage_with_version(original_tarfile, version):
             content = original_tar.extractfile(info)
             repackaged_tar.addfile(info, content)
     return repackaged_tarfile
+
+
+def parse_deployment_properties(fn):
+    deployment_properties = {}
+    with open(fn) as deployment_properties_file:
+        for line in deployment_properties_file.readlines():
+            if line.startswith('#'):
+                # skip comments
+                pass
+            elif '=' in line:
+                k, v = line.split('=')
+                deployment_properties[k] = v.strip()
+    return deployment_properties

--- a/github/deploy.py
+++ b/github/deploy.py
@@ -29,6 +29,12 @@ import sys
 import tempfile
 import zipfile
 
+# usual importing is not possible because
+# this script and module with common functions
+# are at different directory levels in sandbox
+from runpy import run_path
+parse_deployment_properties = run_path('common.py')['parse_deployment_properties']
+
 
 GHR_BINARIES = {
     "Darwin": os.path.abspath("{ghr_osx_binary}"),
@@ -53,19 +59,6 @@ class ZipFile(zipfile.ZipFile):
         attr = member.external_attr >> 16
         os.chmod(ret_val, attr)
         return ret_val
-
-
-def parse_deployment_properties(fn):
-    deployment_properties = {}
-    with open(fn) as deployment_properties_file:
-        for line in deployment_properties_file.readlines():
-            if line.startswith('#'):
-                # skip comments
-                pass
-            elif '=' in line:
-                k, v = line.split('=')
-                deployment_properties[k] = v.strip()
-    return deployment_properties
 
 
 if not os.getenv('DEPLOY_GITHUB_TOKEN'):

--- a/github/rules.bzl
+++ b/github/rules.bzl
@@ -34,14 +34,16 @@ def _deploy_github_impl(ctx):
     )
     files = [
         ctx.file.deployment_properties,
-        ctx.file.version_file
+        ctx.file.version_file,
+        ctx.file._common_py
     ] + ctx.files._ghr
 
     if ctx.file.archive!=None:
         files.append(ctx.file.archive)
 
     symlinks = {
-        "deployment.properties": ctx.file.deployment_properties
+        "deployment.properties": ctx.file.deployment_properties,
+        "common.py": ctx.file._common_py
     }
 
     if ctx.file.release_description:
@@ -93,6 +95,10 @@ deploy_github = rule(
         "_ghr": attr.label_list(
             allow_files = True,
             default = ["@ghr_osx_zip//:ghr", "@ghr_linux_tar//:ghr"]
+        ),
+        "_common_py": attr.label(
+            allow_single_file = True,
+            default = "//common:common.py",
         )
     },
     implementation = _deploy_github_impl,

--- a/maven/BUILD
+++ b/maven/BUILD
@@ -24,3 +24,14 @@ py_binary(
     srcs = ["assemble.py"],
     visibility = ["//visibility:public"]
 )
+
+py_binary(
+    name = "deployment_rules_builder",
+    srcs = [
+        "deployment_rules_builder.py"
+    ],
+    deps = [
+        "//common:common"
+    ],
+    visibility = ["//visibility:public"]
+)

--- a/maven/deployment_rules_builder.py
+++ b/maven/deployment_rules_builder.py
@@ -21,19 +21,7 @@
 
 import sys
 import re
-
-
-def parse_deployment_properties(fn):
-    deployment_properties = {}
-    with open(fn) as deployment_properties_file:
-        for line in deployment_properties_file.readlines():
-            if line.startswith('#'):
-                # skip comments
-                pass
-            elif '=' in line:
-                k, v = line.split('=')
-                deployment_properties[k] = v.strip()
-    return deployment_properties
+from common.common import parse_deployment_properties
 
 
 _, rules_template_fn, rules_output, deployment_properties_fn, deployment_properties_lbl = sys.argv

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -31,18 +31,11 @@ import tempfile
 import zipfile
 from posixpath import join as urljoin
 
-
-def parse_deployment_properties(fn):
-    deployment_properties = {}
-    with open(fn) as deployment_properties_file:
-        for line in deployment_properties_file.readlines():
-            if line.startswith('#'):
-                # skip comments
-                pass
-            elif '=' in line:
-                k, v = line.split('=')
-                deployment_properties[k] = v.strip()
-    return deployment_properties
+# usual importing is not possible because
+# this script and module with common functions
+# are at different directory levels in sandbox
+from runpy import run_path
+parse_deployment_properties = run_path('common.py')['parse_deployment_properties']
 
 
 def sha1(fn):

--- a/maven/templates/rules.bzl
+++ b/maven/templates/rules.bzl
@@ -357,12 +357,14 @@ def _deploy_maven_impl(ctx):
             ctx.attr.target[MavenDeploymentInfo].jar,
             ctx.attr.target[MavenDeploymentInfo].pom,
             ctx.attr.target[MavenDeploymentInfo].srcjar,
-            ctx.file.deployment_properties
+            ctx.file.deployment_properties,
+            ctx.file._common_py
         ], symlinks = {
             lib_jar_link: ctx.attr.target[MavenDeploymentInfo].jar,
             pom_xml_link: ctx.attr.target[MavenDeploymentInfo].pom,
             src_jar_link: ctx.attr.target[MavenDeploymentInfo].jar,
             'deployment.properties': ctx.file.deployment_properties,
+            "common.py": ctx.file._common_py
         })
     )
 
@@ -383,6 +385,10 @@ deploy_maven = rule(
             allow_single_file = True,
             default = "@graknlabs_bazel_distribution//maven/templates:deploy.py",
         ),
+        "_common_py": attr.label(
+            allow_single_file = True,
+            default = "@graknlabs_bazel_distribution//common:common.py",
+        )
     },
     executable = True,
     implementation = _deploy_maven_impl,


### PR DESCRIPTION
## What is the goal of this PR?

Fix #78 
Previously, every rule implementation `parse_deployment_properties` defined itself which resulted in error-prone duplicated code. This PR moved `parse_deployment_properties` into `//common:common.py` and reuses it across rule implementations.

## What are the changes implemented in this PR?

- Added definition of `parse_deployment_properties` to `common.py`
- Remove multiple definitions of `parse_deployment_properties` across rule implementation Python templates
- Add `common.py` to sandbox when executing rules that need `parse_deployment_properties`
- `//common:deployment_rules_builder` is now a proper Python target. However, `exports_files` is still keeped for transition period until `build-tools` is not updated.

[ref](https://docs.python.org/3/library/runpy.html#runpy.run_path) describes the technique used to import `common.py`. Regular `import common` cannot be used since Python implementation script (which is in most cases generated by `bazel` by filling in template) is placed on different level in sandbox than `common.py`.
