### PR TITLE
Split deploy_npm to assemble_npm and deploy_npm

### DIFF
--- a/npm/BUILD
+++ b/npm/BUILD
@@ -26,3 +26,9 @@ bzl_library(
     ],
     visibility = ["//visibility:public"]
 )
+
+py_binary(
+    name = "assemble",
+    srcs = ["assemble.py"],
+    visibility = ["//visibility:public"],
+)

--- a/npm/assemble.py
+++ b/npm/assemble.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+import argparse
+import glob
+import json
+import shutil
+import subprocess
+import os
+import tempfile
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--package', help="NPM package to pack")
+parser.add_argument('--version_file', help="Version file")
+parser.add_argument('--output', help="Output archive")
+
+args = parser.parse_args()
+
+with open(args.version_file) as version_file:
+    version = version_file.read().strip()
+
+new_package_root = tempfile.mktemp()
+shutil.copytree(args.package, new_package_root)
+package_json_fn = os.path.join(new_package_root, 'package.json')
+
+with open(package_json_fn) as f:
+    package_json = json.load(f)
+
+package_json['version'] = version
+
+os.chmod(package_json_fn, 0o755)
+
+with open(package_json_fn, 'w') as f:
+    json.dump(package_json, f)
+
+subprocess.check_call([
+    'npm',
+    'pack'
+], env={
+    'PATH': os.path.realpath('external/nodejs/bin/nodejs/bin/')
+}, cwd=new_package_root)
+
+archives = glob.glob(os.path.join(new_package_root, '*.tgz'))
+if len(archives) != 1:
+    raise Exception('expected one archive instead of {}'.format(archives))
+
+shutil.copy(archives[0], args.output)
+shutil.rmtree(new_package_root)

--- a/npm/rules.bzl
+++ b/npm/rules.bzl
@@ -17,6 +17,108 @@
 # under the License.
 #
 
+def _assemble_npm_impl(ctx):
+    if len(ctx.files.target) != 1:
+        fail("target contains more files than expected")
+    args = ctx.actions.args()
+    args.add('--package', ctx.files.target[0].path)
+    args.add('--output', ctx.outputs.npm_package.path)
+    args.add('--version_file', ctx.file.version_file.path)
+
+    ctx.actions.run(
+        inputs = ctx.files.target + ctx.files._node_runfiles + [ctx.file.version_file],
+        outputs = [ctx.outputs.npm_package],
+        arguments = [args],
+        executable = ctx.executable._assemble_script,
+    )
+
+
+assemble_npm = rule(
+    implementation = _assemble_npm_impl,
+    attrs = {
+        "target": attr.label(
+            mandatory = True,
+            doc = "`npm_library` label to be included in the package",
+        ),
+        "version_file": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "File containing version string"
+        ),
+        "_assemble_script": attr.label(
+            default = "//npm:assemble",
+            executable = True,
+            cfg = "host"
+        ),
+        "_node_runfiles": attr.label(
+            default = Label("@nodejs//:node_runfiles"),
+            allow_files = True
+        )
+    },
+    outputs = {
+          "npm_package": "%{name}.tar.gz",
+    },
+    doc = "Assemble `npm_package` target for further deployment"
+)
+
+
+def _new_deploy_npm(ctx):
+    ctx.actions.expand_template(
+        template = ctx.file._deployment_script_template,
+        output = ctx.outputs.executable,
+        substitutions = {},
+        is_executable = True
+    )
+
+    files = [
+        ctx.file.target,
+        ctx.file.deployment_properties,
+        ctx.file._common_py
+    ]
+    files.extend(ctx.files._node_runfiles)
+
+    return DefaultInfo(
+        executable = ctx.outputs.executable,
+        runfiles = ctx.runfiles(
+            files = files,
+            symlinks = {
+                "deploy_npm.tgz": ctx.file.target,
+                "deployment.properties": ctx.file.deployment_properties,
+                "common.py": ctx.file._common_py
+            }))
+
+
+new_deploy_npm = rule(
+    implementation = _new_deploy_npm,
+    executable = True,
+    attrs = {
+        "target": attr.label(
+            mandatory = True,
+            allow_single_file = True,
+            doc = "`assemble_npm` label to be included in the package",
+        ),
+        "deployment_properties": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "File containing Node repository url by `repo.npm` key"
+        ),
+        "_deployment_script_template": attr.label(
+            allow_single_file = True,
+            default = "//npm/templates:deploy.py",
+        ),
+        "_common_py": attr.label(
+            allow_single_file = True,
+            default = "//common:common.py"
+        ),
+        "_node_runfiles": attr.label(
+            default = Label("@nodejs//:node_runfiles"),
+            allow_files = True
+        ),
+    },
+
+)
+
+
 def _deploy_npm_impl(ctx):
     preprocessed_deploy_script = ctx.actions.declare_file('_deploy.sh')
 

--- a/npm/templates/BUILD
+++ b/npm/templates/BUILD
@@ -1,2 +1,2 @@
 
-exports_files(["deploy.sh"])
+exports_files(["deploy.py", "deploy.sh"])

--- a/npm/templates/deploy.py
+++ b/npm/templates/deploy.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+
+import argparse
+import io
+import json
+import os
+import subprocess
+
+# usual importing is not possible because
+# this script and module with common functions
+# are at different directory levels in sandbox
+import tarfile
+import tempfile
+from runpy import run_path
+parse_deployment_properties = run_path('common.py')['parse_deployment_properties']
+
+
+def git_commit():
+    return subprocess.check_output([
+        'git',
+        'rev-parse',
+        'HEAD'
+    ], cwd=os.getenv('BUILD_WORKSPACE_DIRECTORY')).decode().strip()
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('repo_type')
+args = parser.parse_args()
+
+NPM_REPO_PREFIX = 'repo.npm.'
+repo_type_key = NPM_REPO_PREFIX + args.repo_type
+
+properties = parse_deployment_properties('deployment.properties')
+if repo_type_key not in properties:
+    raise Exception('invalid repo type {}. valid repo types are: {}'.format(
+        args.repo_type,
+        list(
+            map(lambda x: x.replace(NPM_REPO_PREFIX, ''),
+                filter(lambda x: x.startswith(NPM_REPO_PREFIX), properties)))
+    ))
+
+npm_registry = properties[repo_type_key]
+
+npm_username, npm_password, npm_email = (
+    os.getenv('DEPLOY_NPM_USERNAME'),
+    os.getenv('DEPLOY_NPM_PASSWORD'),
+    os.getenv('DEPLOY_NPM_EMAIL'),
+)
+
+if not npm_username:
+    raise Exception(
+        'username should be passed via '
+        '$DEPLOY_NPM_USERNAME env variable'
+    )
+
+if not npm_password:
+    raise Exception(
+        'password should be passed via '
+        '$DEPLOY_NPM_PASSWORD env variable'
+    )
+
+if not npm_email:
+    raise Exception(
+        'email should be passed via '
+        '$DEPLOY_NPM_EMAIL env variable'
+    )
+
+expect_input_tmpl = '''spawn npm adduser --registry={registry}
+expect {{
+  "Username:" {{send "{username}\r"; exp_continue}}
+  "Password:" {{send "{password}\r"; exp_continue}}
+  "Email: (this IS public)" {{send "{email}\r"; exp_continue}}
+}}'''
+
+
+with tempfile.NamedTemporaryFile('wt', delete=False) as expect_input_file:
+    expect_input_file.write(expect_input_tmpl.format(
+        registry=npm_registry,
+        username=npm_username,
+        password=npm_password,
+        email=npm_email,
+    ))
+
+with open(expect_input_file.name) as expect_input:
+    subprocess.check_call([
+        '/usr/bin/expect',
+    ], stdin=expect_input, env={
+        'PATH': os.path.realpath('external/nodejs/bin/nodejs/bin/')
+    })
+
+
+if args.repo_type == 'snapshot':
+    print('Appending git commit to version')
+    with tarfile.open('deploy_npm.tgz') as tf, tarfile.open('deploy_npm_updated.tgz', 'w:gz') as tfu:
+        pkg_json_file = tf.extractfile('package/package.json')
+        pkg_json = json.loads(pkg_json_file.read().decode())
+        pkg_json['version'] += "-{}".format(git_commit())
+        pkg_json_file.close()
+
+        for info in sorted(tf.getmembers(), key=lambda x: x.path):
+            content = tf.extractfile(info)
+            if info.path == 'package/package.json':
+                content = io.BytesIO()
+                content.write(json.dumps(pkg_json).encode())
+                info.size = content.tell()
+                content.seek(0)
+            tfu.addfile(info, content)
+
+subprocess.check_call([
+    'npm',
+    'publish',
+    '--registry={}'.format(npm_registry),
+    'deploy_npm_updated.tgz'
+], env={
+    'PATH': os.path.realpath('external/nodejs/bin/nodejs/bin/')
+})
+
+os.remove('deploy_npm_updated.tgz')


### PR DESCRIPTION
## What is the goal of this PR?

Fix #59 
`deploy_npm` is split into `assemble_npm` and `new_deploy_npm` [to be later renamed to `deploy_npm`] for consistency with existing rules (i.e. `assemble_maven`/`deploy_maven`)

## What are the changes implemented in this PR?

- Implement `assemble_npm` which packs package for later deployment
- Implement `new_deploy_npm` which uploads the package built with `assemble_npm`
