### PR TITLE
Deploy correct artifact as source JAR

### DIFF
--- a/maven/templates/rules.bzl
+++ b/maven/templates/rules.bzl
@@ -362,7 +362,7 @@ def _deploy_maven_impl(ctx):
         ], symlinks = {
             lib_jar_link: ctx.attr.target[MavenDeploymentInfo].jar,
             pom_xml_link: ctx.attr.target[MavenDeploymentInfo].pom,
-            src_jar_link: ctx.attr.target[MavenDeploymentInfo].jar,
+            src_jar_link: ctx.attr.target[MavenDeploymentInfo].srcjar,
             'deployment.properties': ctx.file.deployment_properties,
             "common.py": ctx.file._common_py
         })


### PR DESCRIPTION
## What is the goal of this PR?

Typo in `rules.bzl` resulted in incorrectly deploying JAR with `.class` files as source JAR.

## What are the changes implemented in this PR?

Correctly symlink source JAR during deployment
