### PR TITLE
Introduce assemble_pip and new_deploy_pip rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,3 +41,19 @@ node_repositories()
 
 load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
 sass_repositories()
+
+git_repository(
+    name = "io_bazel_rules_python",
+    remote = "https://github.com/bazelbuild/rules_python.git",
+    commit = "fdbb17a4118a1728d19e638a5291b4c4266ea5b8",
+)
+
+load("@io_bazel_rules_python//python:pip.bzl", "pip_repositories", "pip_import")
+pip_repositories()
+
+pip_import(
+    name = "graknlabs_bazel_distribution_pip",
+    requirements = "//pip:requirements.txt",
+)
+load("@graknlabs_bazel_distribution_pip//:requirements.bzl", graknlabs_bazel_distribution_pip_install = "pip_install")
+graknlabs_bazel_distribution_pip_install()

--- a/pip/assemble.py
+++ b/pip/assemble.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import argparse
+import glob
+import os
+import shutil
+import tempfile
+from distutils.core import run_setup
+
+
+def create_init_files(directory):
+    from os import walk
+    from os.path import join
+    for dirName, subdirList, fileList in walk(directory):
+        if "__init__.py" not in fileList:
+            open(join(dirName, "__init__.py"), "w").close()
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--output', help="Output archive")
+parser.add_argument('--setup_py', help="setup.py")
+parser.add_argument('--readme', help="README file")
+parser.add_argument('--files', nargs='+', help='Python files to pack into archive')
+parser.add_argument('--package_root', help='Folder considered to be the root of all source code')
+
+args = parser.parse_args()
+
+# absolutize the path
+args.output = os.path.abspath(args.output)
+
+# new package root
+pkg_dir = tempfile.mkdtemp()
+
+
+for f in args.files:
+    # descend into package root
+    fn = f[f.find(args.package_root):]
+    try:
+        e = os.path.join(pkg_dir, os.path.dirname(fn))
+        os.makedirs(e)
+    except OSError:
+        # directory already exists
+        pass
+    shutil.copy(f, os.path.join(pkg_dir, fn))
+
+setup_py = os.path.join(pkg_dir, 'setup.py')
+readme = os.path.join(pkg_dir, 'README.md')
+shutil.copy(args.setup_py, setup_py)
+shutil.copy(args.readme, readme)
+
+with open(os.path.join(pkg_dir, 'setup.cfg'), 'w') as setup_cfg:
+    setup_cfg.writelines([
+        '[bdist_wheel]\n',
+        'universal = 1\n'
+    ])
+
+# change directory into new package root
+os.chdir(pkg_dir)
+
+# ensure every folder is a Python package
+create_init_files(pkg_dir)
+
+# pack sources
+run_setup(setup_py, ['sdist'])
+
+archives = glob.glob('dist/*.tar.gz')
+if len(archives) != 1:
+    raise Exception('archive expected was not produced by sdist')
+
+shutil.copy(archives[0], args.output)
+shutil.rmtree(pkg_dir)

--- a/pip/templates/BUILD
+++ b/pip/templates/BUILD
@@ -17,4 +17,4 @@
 # under the License.
 #
 
-exports_files(["setup.py", "deploy.sh"])
+exports_files(["new_setup.py", "setup.py", "deploy.py", "deploy.sh"])

--- a/pip/templates/deploy.py
+++ b/pip/templates/deploy.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+import argparse
+import glob
+import os
+import shutil
+import sys
+
+
+sys.path.extend(map(os.path.abspath, glob.glob('external/*/')))
+# noinspection PyUnresolvedReferences
+import twine.commands.upload
+
+# usual importing is not possible because
+# this script and module with common functions
+# are at different directory levels in sandbox
+from runpy import run_path
+parse_deployment_properties = run_path('common.py')['parse_deployment_properties']
+
+parser = argparse.ArgumentParser()
+parser.add_argument('repo_type')
+args = parser.parse_args()
+
+PIP_REPO_PREFIX = 'repo.pypi.'
+repo_type_key = PIP_REPO_PREFIX + args.repo_type
+
+properties = parse_deployment_properties('deployment.properties')
+if repo_type_key not in properties:
+    raise Exception('invalid repo type {}. valid repo types are: {}'.format(
+        args.repo_type,
+        list(
+            map(lambda x: x.replace(PIP_REPO_PREFIX, ''),
+                filter(lambda x: x.startswith(PIP_REPO_PREFIX), properties)))
+    ))
+
+pip_registry = properties[repo_type_key]
+
+pip_username, pip_password = (
+    os.getenv('DEPLOY_PIP_USERNAME'),
+    os.getenv('DEPLOY_PIP_PASSWORD'),
+)
+
+if not pip_username:
+    raise Exception(
+        'username should be passed via '
+        'DEPLOY_PIP_USERNAME env variable'
+    )
+
+if not pip_password:
+    raise Exception(
+        'password should be passed via '
+        '$DEPLOY_PIP_PASSWORD env variable'
+    )
+
+with open("{version_file}") as version_file:
+    version = version_file.read().strip()
+
+new_package_file = None
+
+try:
+    new_package_file = "{package_file}".replace(".tar.gz", "-{}.tar.gz".format(version))
+    shutil.copy("{package_file}", new_package_file)
+
+    twine.commands.upload.main([
+        new_package_file,
+        '-u',
+        pip_username,
+        '-p',
+        pip_password,
+        '--repository-url',
+        pip_registry
+    ])
+finally:
+    if new_package_file:
+        os.remove(new_package_file)

--- a/pip/templates/new_setup.py
+++ b/pip/templates/new_setup.py
@@ -17,25 +17,24 @@
 # under the License.
 #
 
-exports_files(["replace_imports.py", "requirements.txt"])
+from setuptools import setup
+from setuptools import find_packages
 
-load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
-load("@graknlabs_bazel_distribution_pip//:requirements.bzl", graknlabs_bazel_distribution_requirement = "requirement")
+packages = find_packages()
 
-
-bzl_library(
-    name = "lib",
-    srcs = [
-        "rules.bzl",
-    ],
-    visibility = ["//visibility:public"]
-)
-
-py_binary(
-    name = "assemble",
-    srcs = ["assemble.py"],
-    deps = [
-        graknlabs_bazel_distribution_requirement("setuptools")
-    ],
-    visibility = ["//visibility:public"]
+setup(
+    name = "{name}",
+    version = "{version}",
+    description = "{description}",
+    long_description = open('README.md').read(),
+    long_description_content_type="text/markdown",
+    classifiers = {classifiers},
+    keywords = "{keywords}",
+    url = "{url}",
+    author = "{author}",
+    author_email = "{author_email}",
+    license = "{license}",
+    packages=packages,
+    install_requires={install_requires},
+    zip_safe=False,
 )


### PR DESCRIPTION
## What is the goal of this PR?

Fix #58
`deploy_pip` is split into `assemble_pip` and `new_deploy_pip` [to be later renamed to `deploy_pip`] for consistency with existing rules (i.e. `assemble_maven`/`deploy_maven`)

## What are the changes implemented in this PR?

- Implement `assemble_pip` which packs package for later deployment
- Implement `new_deploy_pip` which uploads the package built with `assemble_pip`
