### PR TITLE
Use unique names for files declared by deploy_pip/deploy_github

### DIFF
--- a/github/rules.bzl
+++ b/github/rules.bzl
@@ -18,7 +18,7 @@
 #
 
 def _deploy_github_impl(ctx):
-    _deploy_script = ctx.actions.declare_file("_deploy.py")
+    _deploy_script = ctx.actions.declare_file("{}_deploy.py".format(ctx.attr.name))
 
     ctx.actions.expand_template(
         template = ctx.file._deploy_script,

--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -171,7 +171,7 @@ def _assemble_pip_impl(ctx):
 
 
 def _new_deploy_pip_impl(ctx):
-    deployment_script = ctx.actions.declare_file("_deploy.py")
+    deployment_script = ctx.actions.declare_file("{}_deploy.py".format(ctx.attr.name))
 
     ctx.actions.expand_template(
         template = ctx.file._deploy_py_template,


### PR DESCRIPTION
## What is the goal of this PR?

Previously putting `deploy_github` and `deploy_pip` targets in the same `bazel` package would trigger build error.

## What are the changes implemented in this PR?

Files declared by `deploy_github` and `deploy_pip` had the same name (`_deploy.py`). This PR deduplicates `ctx.actions.declare_file` invocations by prepending invoking target name (which is unique as `bazel` targets should have names unique across the package).
