### PR TITLE
Schedule npm assembly action for local execution

### DIFF
--- a/npm/assemble.py
+++ b/npm/assemble.py
@@ -39,7 +39,9 @@ with open(args.version_file) as version_file:
     version = version_file.read().strip()
 
 new_package_root = tempfile.mktemp()
-shutil.copytree(args.package, new_package_root)
+shutil.copytree(args.package, new_package_root,
+                ignore=lambda _, names: list(
+                    filter(lambda x: 'external' in x, names)))
 package_json_fn = os.path.join(new_package_root, 'package.json')
 
 with open(package_json_fn) as f:
@@ -51,6 +53,14 @@ os.chmod(package_json_fn, 0o755)
 
 with open(package_json_fn, 'w') as f:
     json.dump(package_json, f)
+
+
+os.chmod(new_package_root, 0o755)
+for root, dirs, files in os.walk(new_package_root):
+    for d in dirs:
+        os.chmod(os.path.join(root, d), 0o755)
+    for f in files:
+        os.chmod(os.path.join(root, f), 0o755)
 
 subprocess.check_call([
     'npm',

--- a/npm/rules.bzl
+++ b/npm/rules.bzl
@@ -30,6 +30,9 @@ def _assemble_npm_impl(ctx):
         outputs = [ctx.outputs.npm_package],
         arguments = [args],
         executable = ctx.executable._assemble_script,
+        execution_requirements = {
+            "local": "1"
+        }
     )
 
 


### PR DESCRIPTION
## What is the goal of this PR?

Fix building of `assemble_npm` by never executing it remotely

## What are the changes implemented in this PR?

- Previously, `npm pack` (invoked in `assemble.py` - script used by `assemble_npm`) would fail, not being able to resolve `../lib/utils/unsupported.js`. As this only happened on RBE, we now always schedule this action to be executed in the sandbox.
- In the sandbox, `new_package_root` was produced without having `+w` permission — which resulted in not being able to write files into the directory (`npm pack`) or removing it (`shutil.rmtree`)
