### PR TITLE
assemble_apt: allow referencing other bazel workspaces in dependencies

### DIFF
--- a/apt/BUILD
+++ b/apt/BUILD
@@ -29,3 +29,9 @@ bzl_library(
     ],
     visibility = ["//visibility:public"]
 )
+
+py_binary(
+    name = "generate_depends_file",
+    srcs = ["generate_depends_file.py"],
+    visibility = ["//visibility:public"]
+)

--- a/apt/generate_depends_file.py
+++ b/apt/generate_depends_file.py
@@ -47,7 +47,7 @@ if args.workspace_refs:
         workspace_refs = json.load(f)
 
 for ws, commit in workspace_refs['commits'].items():
-    replacements["%{{@{}}}".format(ws)] = commit
+    replacements["%{{@{}}}".format(ws)] = "0.0.0-" + commit
 
 for ws, tag in workspace_refs['tags'].items():
     replacements["%{{@{}}}".format(ws)] = tag

--- a/apt/generate_depends_file.py
+++ b/apt/generate_depends_file.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import argparse
+import json
+import os
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--output', required=True, help='Output file')
+parser.add_argument('--version_file', required=True, help='File containing version of package being built')
+parser.add_argument('--workspace_refs', help='Optional file with workspace references')
+parser.add_argument('--deps', nargs='+', required=True, help='Dependency declarations')
+args = parser.parse_args()
+
+workspace_refs = {
+    'commits': {},
+    'tags': {}
+}
+
+with open(args.version_file) as f:
+    version = f.read().strip()
+
+replacements = {
+    "{version}": version
+}
+
+if args.workspace_refs:
+    with open(args.workspace_refs) as f:
+        workspace_refs = json.load(f)
+
+for ws, commit in workspace_refs['commits'].items():
+    replacements["%{{@{}}}".format(ws)] = commit
+
+for ws, tag in workspace_refs['tags'].items():
+    replacements["%{{@{}}}".format(ws)] = tag
+
+deps = []
+
+for dep in args.deps:
+    for replacement_key, replacement_val in replacements.items():
+        dep = dep.replace(replacement_key, replacement_val)
+    deps.append(dep)
+
+with open(args.output, 'w') as out:
+    out.write(', '.join(deps))

--- a/apt/pkg_deb_modified_from_bazel/make_deb.py
+++ b/apt/pkg_deb_modified_from_bazel/make_deb.py
@@ -43,7 +43,7 @@ DEBIAN_FIELDS = [
     ('Maintainer', True, False),
     ('Description', True, True),
     ('Homepage', False, False),
-    ('Built-Using', False, False, 'Bazel'),
+    ('Built-Using', False, False, None),
     ('Distribution', False, False, 'unstable'),
     ('Urgency', False, False, 'medium'),
 ]
@@ -66,6 +66,10 @@ gflags.DEFINE_string('prerm', None,
                      'The prerm script (prefix with @ to provide a path).')
 gflags.DEFINE_string('postrm', None,
                      'The postrm script (prefix with @ to provide a path).')
+gflags.DEFINE_string('config', None,
+                     'The config script (prefix with @ to provide a path).')
+gflags.DEFINE_string('templates', None,
+                     'The templates file (prefix with @ to provide a path).')
 
 # size of chunks for copying package content to final .deb file
 # This is a wild guess, but I am not convinced of the value of doing much work
@@ -131,7 +135,7 @@ def AddArFileEntry(fileobj, filename,
         fileobj.write(b'\n')  # 2-byte alignment padding
 
 
-def MakeDebianControlField(name, value, wrap=False, substitutions=None):
+def MakeDebianControlField(name, value, wrap=False):
     """Add a field to a debian control file."""
     result = name + ': '
     if isinstance(value, str):
@@ -145,24 +149,18 @@ def MakeDebianControlField(name, value, wrap=False, substitutions=None):
                                break_long_words=False)
     else:
         result += value
-    if substitutions:
-        for k, v in substitutions.items():
-            result = result.replace(k, v)
     return result.replace(u'\n', u'\n ') + u'\n'
 
 
 def CreateDebControl(extrafiles=None, **kwargs):
     """Create the control.tar.gz file."""
     # create the control file
-    version = kwargs.get('version', '')
     controlfile = ''
     for values in DEBIAN_FIELDS:
         fieldname = values[0]
         key = fieldname[0].lower() + fieldname[1:].replace('-', '')
         if values[1] or (key in kwargs and kwargs[key]):
-            controlfile += MakeDebianControlField(fieldname, kwargs[key], values[2], {
-                '{version}': version
-            })
+            controlfile += MakeDebianControlField(fieldname, kwargs[key], values[2])
     # Create the control.tar file
     tar = BytesIO()
     with gzip.GzipFile('control.tar.gz', mode='w', fileobj=tar, mtime=0) as gz:
@@ -188,6 +186,8 @@ def CreateDeb(output,
               postinst=None,
               prerm=None,
               postrm=None,
+              config=None,
+              templates=None,
               conffiles=None,
               **kwargs):
     """Create a full debian package."""
@@ -200,6 +200,10 @@ def CreateDeb(output,
         extrafiles['prerm'] = (prerm, 0o755)
     if postrm:
         extrafiles['postrm'] = (postrm, 0o755)
+    if config:
+        extrafiles['config'] = (config, 0o755)
+    if templates:
+        extrafiles['templates'] = (templates, 0o755)
     if conffiles:
         extrafiles['conffiles'] = ('\n'.join(conffiles) + '\n', 0o644)
     control = CreateDebControl(extrafiles=extrafiles, **kwargs)
@@ -328,6 +332,8 @@ def main(unused_argv):
         postinst=GetFlagValue(FLAGS.postinst, False),
         prerm=GetFlagValue(FLAGS.prerm, False),
         postrm=GetFlagValue(FLAGS.postrm, False),
+        config=GetFlagValue(FLAGS.config, False),
+        templates=GetFlagValue(FLAGS.templates, False),
         conffiles=GetFlagValues(FLAGS.conffile),
         package=FLAGS.package,
         version=GetFlagValue(FLAGS.version),
@@ -335,7 +341,7 @@ def main(unused_argv):
         maintainer=FLAGS.maintainer,
         section=FLAGS.section,
         architecture=FLAGS.architecture,
-        depends=FLAGS.depends,
+        depends=GetFlagValues(FLAGS.depends),
         suggests=FLAGS.suggests,
         enhances=FLAGS.enhances,
         preDepends=FLAGS.pre_depends,


### PR DESCRIPTION
## What is the goal of this PR?

Fix #151
Rules for assembling Debian packages should allow referencing other Bazel workspaces in `depends` attribute.

## What are the changes implemented in this PR?

- Sync `apt/pkg_deb_modified_from_bazel/` with latest `master` of Bazel sources — version that is bundled with `0.26.1` is buggy (bazelbuild/bazel#8518) and we cannot yet use `0.27.0` (bazelbuild/bazel#8659)
- Add optional argument `workspace_refs` to `assemble_apt` — if it's passed, it's used for substitutions in `depends` attribute