### PR TITLE
assemble_rpm: allow referencing other bazel workspaces in spec file

### DIFF
--- a/rpm/BUILD
+++ b/rpm/BUILD
@@ -26,3 +26,9 @@ bzl_library(
     ],
     visibility = ["//visibility:public"]
 )
+
+py_binary(
+    name = "generate_spec_file",
+    srcs = ["generate_spec_file.py"],
+    visibility = ["//visibility:public"]
+)


### PR DESCRIPTION
## What is the goal of this PR?

Fix #152
Rules for assembling RPM packages should allow referencing other Bazel workspaces in `.spec` file

## What are the changes implemented in this PR?

- Add optional argument `workspace_refs` to `assemble_apt` — if it's passed, it's used for substitutions in `spec` file