### PR TITLE
Fix assemble_pip

### DIFF
--- a/pip/assemble.py
+++ b/pip/assemble.py
@@ -50,7 +50,7 @@ args.output = os.path.abspath(args.output)
 # turn imports into regex patterns
 args.imports = list(map(
     lambda imp: re.compile('(?:.*){}[/]?(?P<fn>.*)'.format(imp)),
-    args.imports
+    args.imports or []
 ))
 
 # new package root


### PR DESCRIPTION
## What is the goal of this PR?

We fix assemble.py to no longer require the `--imports` flag to be supplied in order to assemble correctly.