### PR TITLE
Streamlined versioning for assemble_apt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1409,7 +1409,7 @@ TransitiveJarToMavenCoordinatesMapping(<a href="#TransitiveJarToMavenCoordinates
 ## assemble_apt
 
 <pre>
-assemble_apt(<a href="#assemble_apt-name">name</a>, <a href="#assemble_apt-package_name">package_name</a>, <a href="#assemble_apt-maintainer">maintainer</a>, <a href="#assemble_apt-version_file">version_file</a>, <a href="#assemble_apt-description">description</a>, <a href="#assemble_apt-installation_dir">installation_dir</a>, <a href="#assemble_apt-workspace_refs">workspace_refs</a>, <a href="#assemble_apt-archives">archives</a>, <a href="#assemble_apt-empty_dirs">empty_dirs</a>, <a href="#assemble_apt-files">files</a>, <a href="#assemble_apt-depends">depends</a>, <a href="#assemble_apt-symlinks">symlinks</a>, <a href="#assemble_apt-permissions">permissions</a>)
+assemble_apt(<a href="#assemble_apt-name">name</a>, <a href="#assemble_apt-package_name">package_name</a>, <a href="#assemble_apt-maintainer">maintainer</a>, <a href="#assemble_apt-description">description</a>, <a href="#assemble_apt-version_file">version_file</a>, <a href="#assemble_apt-installation_dir">installation_dir</a>, <a href="#assemble_apt-workspace_refs">workspace_refs</a>, <a href="#assemble_apt-archives">archives</a>, <a href="#assemble_apt-empty_dirs">empty_dirs</a>, <a href="#assemble_apt-files">files</a>, <a href="#assemble_apt-depends">depends</a>, <a href="#assemble_apt-symlinks">symlinks</a>, <a href="#assemble_apt-permissions">permissions</a>)
 </pre>
 
 Assemble package for installation with APT
@@ -1452,16 +1452,6 @@ Assemble package for installation with APT
         </p>
       </td>
     </tr>
-    <tr id="assemble_apt-version_file">
-      <td><code>version_file</code></td>
-      <td>
-        required.
-        <p>
-          File containing version number of a package
-    https://www.debian.org/doc/debian-policy/ch-controlfields#version
-        </p>
-      </td>
-    </tr>
     <tr id="assemble_apt-description">
       <td><code>description</code></td>
       <td>
@@ -1469,6 +1459,19 @@ Assemble package for installation with APT
         <p>
           description of the built package
     https://www.debian.org/doc/debian-policy/ch-controlfields#description
+        </p>
+      </td>
+    </tr>
+    <tr id="assemble_apt-version_file">
+      <td><code>version_file</code></td>
+      <td>
+        optional. default is <code>None</code>
+        <p>
+          File containing version number of a package.
+    Alternatively, pass --define version=VERSION to Bazel invocation.
+    Specifying commit SHA will result in prepending '0.0.0' to it to comply with Debian rules.
+    Not specifying version at all defaults to '0.0.0'
+    https://www.debian.org/doc/debian-policy/ch-controlfields#version
         </p>
       </td>
     </tr>

--- a/apt/rules.bzl
+++ b/apt/rules.bzl
@@ -20,11 +20,32 @@
 load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar")
 load("//apt/pkg_deb_modified_from_bazel:pkg.bzl", "pkg_deb")
 
+def _assemble_apt_version_file_impl(ctx):
+    version = ctx.var.get('version', '0.0.0')
+
+    if len(version) == 40:
+        # this is a commit SHA, most likely
+        version = "0.0.0-{}".format(version)
+
+    ctx.actions.run_shell(
+        inputs = [],
+        outputs = [ctx.outputs.version_file],
+        command = "echo {} > {}".format(version, ctx.outputs.version_file.path)
+    )
+
+
+_assemble_apt_version_file = rule(
+    outputs = {
+        "version_file": "%{name}.version"
+    },
+    implementation = _assemble_apt_version_file_impl
+)
+
 def assemble_apt(name,
                  package_name,
                  maintainer,
-                 version_file,
                  description,
+                 version_file = None,
                  installation_dir = None,
                  workspace_refs = None,
                  archives = [],
@@ -42,10 +63,13 @@ def assemble_apt(name,
         maintainer: The package maintainer's name and email address.
             The name must come first, then the email address
             inside angle brackets <> (in RFC822 format)
-        version_file: File containing version number of a package
-            https://www.debian.org/doc/debian-policy/ch-controlfields#version
         description: description of the built package
             https://www.debian.org/doc/debian-policy/ch-controlfields#description
+        version_file: File containing version number of a package.
+            Alternatively, pass --define version=VERSION to Bazel invocation.
+            Specifying commit SHA will result in prepending '0.0.0' to it to comply with Debian rules.
+            Not specifying version at all defaults to '0.0.0'
+            https://www.debian.org/doc/debian-policy/ch-controlfields#version
         installation_dir: directory into which .deb package is unpacked at installation
         workspace_refs: JSON file with other Bazel workspace references
         archives: Bazel labels of archives that go into .deb package
@@ -77,6 +101,11 @@ def assemble_apt(name,
         pkg_tar(name = tar_name + "__do_not_reference__empty")
         deb_data = tar_name + "__do_not_reference__empty"
 
+    if not version_file:
+        version_file = name + "__version__do_not_reference"
+        _assemble_apt_version_file(
+            name = version_file
+        )
     args = [
         "$(location @graknlabs_bazel_distribution//apt:generate_depends_file)",
         "--output", "$@",


### PR DESCRIPTION
## What is the goal of this PR?

Incremental work on #150 for `assemble_apt` rule

## What are the changes implemented in this PR?

- Make `version_file` in `assemble_apt` optional
- Add private rule (`_assemble_apt_version_file`) which exposes version from Bazel command line as a file. Use this file in absence of `version_file` in `assemble_apt`.

### Sample usage
Invoking assembly would be the same; `--define version=<VERSION>` would be added as command-line argument:
`bazel build --define version=$(git rev-parse HEAD) //console:assemble-linux-apt`