### PR TITLE
Streamlined versioning for java_deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -953,9 +953,11 @@ Packs Java library alongside with its dependencies into archive
     <tr id="java_deps-version_file">
       <td><code>version_file</code></td>
       <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
         <p>
-          File containing version string
+          File containing version string.
+            Alternatively, pass --define version=VERSION to Bazel invocation.
+            Not specifying version at all defaults to '0.0.0'
         </p>
       </td>
     </tr>


### PR DESCRIPTION
## What is the goal of this PR?

Incremental work on #150 for `java_deps` rule

## What are the changes implemented in this PR?

- Make `version_file` in `java_deps` optional
- Exposes version from Bazel command line as a file if `version_file` is not present.

### Sample usage
Invoking assembly would be the same; `--define version=<VERSION>` would be added as command-line argument:
`bazel build --define version=$(git rev-parse HEAD) //console:console-deps`