### PR TITLE
Streamlined versioning for assemble_maven

### DIFF
--- a/maven/_pom_replace_version.py
+++ b/maven/_pom_replace_version.py
@@ -38,5 +38,6 @@ with open(preprocessed_template_path, 'r') as template_file, \
         pom = pom.replace(workspace, refs['commits'][workspace])
     for workspace in refs['tags']:
         pom = pom.replace(workspace, refs['tags'][workspace])
+    pom = pom.replace('{pom_version}', version)
 
     pom_file.write(pom)


### PR DESCRIPTION
## What is the goal of this PR?

Incremental work on #150 for `assemble_maven` rule

## What are the changes implemented in this PR?

- Make `version_file` in `assemble_maven` optional
- Exposes version from Bazel command line as a file if `version_file` is not present.
- Replace `{pom_version}` [placeholder] in `pom.xml`
- Remove `version_file` from runfiles of assemble script — it's not used there

### Sample usage
Invoking assembly would be the same; `--define version=<VERSION>` would be added as command-line argument:
`bazel build --define version=$(git rev-parse HEAD) //console:assemble-maven`