### PR TITLE
Streamlined versioning for assemble_npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,9 +102,11 @@ Assemble Java package for subsequent deployment to Maven repo
     <tr id="assemble_maven-version_file">
       <td><code>version_file</code></td>
       <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
         <p>
-          File containing version string
+          File containing version string.
+            Alternatively, pass --define version=VERSION to Bazel invocation.
+            Not specifying version at all defaults to '0.0.0'
         </p>
       </td>
     </tr>
@@ -160,9 +162,11 @@ Assemble `npm_package` target for further deployment
     <tr id="assemble_npm-version_file">
       <td><code>version_file</code></td>
       <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
         <p>
-          File containing version string
+          File containing version string.
+            Alternatively, pass --define version=VERSION to Bazel invocation.
+            Not specifying version at all defaults to '0.0.0'
         </p>
       </td>
     </tr>
@@ -601,9 +605,11 @@ Deploy `assemble_versioned` target to GitHub Releases
     <tr id="deploy_github-version_file">
       <td><code>version_file</code></td>
       <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
         <p>
-          File containing version string
+          File containing version string.
+            Alternatively, pass --define version=VERSION to Bazel invocation.
+            Not specifying version at all defaults to '0.0.0'
         </p>
       </td>
     </tr>

--- a/maven/templates/rules.bzl
+++ b/maven/templates/rules.bzl
@@ -290,7 +290,11 @@ assemble_maven = rule(
         ),
         "version_file": attr.label(
             allow_single_file = True,
-            doc = "File containing version string"
+            doc = """
+            File containing version string.
+            Alternatively, pass --define version=VERSION to Bazel invocation.
+            Not specifying version at all defaults to '0.0.0'
+            """
         ),
         "workspace_refs": attr.label(
             mandatory = True,


### PR DESCRIPTION
## What is the goal of this PR?

Incremental work on #150 for `assemble_npm` rule

## What are the changes implemented in this PR?

- Make `version_file` in `assemble_npm` optional
- Exposes version from Bazel command line as a file if `version_file` is not present.
- Follow-up to #164: add docs to `version_file` of `assemble_maven`

### Sample usage
Invoking assembly would be the same; `--define version=<VERSION>` would be added as command-line argument:
`bazel build --define version=$(git rev-parse HEAD) //:assemble-npm`