### PR TITLE
Streamlined versioning for assemble_pip

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,9 +303,11 @@ assemble_pip(<a href="#assemble_pip-name">name</a>, <a href="#assemble_pip-autho
     <tr id="assemble_pip-version_file">
       <td><code>version_file</code></td>
       <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
         <p>
-          File containing version string
+          File containing version string.
+            Alternatively, pass --define version=VERSION to Bazel invocation.
+            Not specifying version at all defaults to '0.0.0'
         </p>
       </td>
     </tr>


### PR DESCRIPTION
## What is the goal of this PR?

Incremental work on #150 for `assemble_pip` rule

## What are the changes implemented in this PR?

- Make `version_file` in `assemble_pip` optional
- Exposes version from Bazel command line as a file if `version_file` is not present.

### Sample usage
Invoking assembly would be the same; `--define version=<VERSION>` would be added as command-line argument:
`bazel build --define version=$(git rev-parse HEAD) //:assemble-pip`