### PR TITLE
Add tags to genrule for assemble_targz

### DIFF
--- a/common/rules.bzl
+++ b/common/rules.bzl
@@ -75,7 +75,8 @@ def assemble_targz(name,
         srcs = [":{}__do_not_reference__targz_1".format(name)],
         cmd = "cp $$(echo $(SRCS) | awk '{print $$1}') $@",
         outs = [output_filename + ".tar.gz"],
-        visibility = visibility
+        visibility = visibility,
+        tags = tags,
     )
 
 


### PR DESCRIPTION
Follow up to #168, I forgot to pass tags to another rule within assemble_targz