### PR TITLE
Prepare for upgrading of @build_bazel_rules_nodejs

### DIFF
--- a/npm/assemble.py
+++ b/npm/assemble.py
@@ -66,7 +66,14 @@ subprocess.check_call([
     'npm',
     'pack'
 ], env={
-    'PATH': os.path.realpath('external/nodejs/bin/nodejs/bin/')
+    'PATH': ':'.join([
+        '/usr/bin/',
+        '/bin/',
+        os.path.realpath('external/nodejs/bin/nodejs/bin/'),
+        os.path.realpath('external/nodejs_darwin_amd64/bin/'),
+        os.path.realpath('external/nodejs_linux_amd64/bin/'),
+        os.path.realpath('external/nodejs_windows_amd64/bin/'),
+    ])
 }, cwd=new_package_root)
 
 archives = glob.glob(os.path.join(new_package_root, '*.tgz'))

--- a/npm/rules.bzl
+++ b/npm/rules.bzl
@@ -39,7 +39,7 @@ def _assemble_npm_impl(ctx):
     args.add('--version_file', version_file.path)
 
     ctx.actions.run(
-        inputs = ctx.files.target + ctx.files._node_runfiles + [version_file],
+        inputs = ctx.files.target + ctx.files._npm + [version_file],
         outputs = [ctx.outputs.npm_package],
         arguments = [args],
         executable = ctx.executable._assemble_script,
@@ -69,8 +69,8 @@ assemble_npm = rule(
             executable = True,
             cfg = "host"
         ),
-        "_node_runfiles": attr.label(
-            default = Label("@nodejs//:node_runfiles"),
+        "_npm": attr.label(
+            default = Label("@nodejs//:npm"),
             allow_files = True
         )
     },
@@ -94,7 +94,7 @@ def _deploy_npm(ctx):
         ctx.file.deployment_properties,
         ctx.file._common_py
     ]
-    files.extend(ctx.files._node_runfiles)
+    files.extend(ctx.files._npm)
 
     return DefaultInfo(
         executable = ctx.outputs.executable,
@@ -129,8 +129,8 @@ deploy_npm = rule(
             allow_single_file = True,
             default = "//common:common.py"
         ),
-        "_node_runfiles": attr.label(
-            default = Label("@nodejs//:node_runfiles"),
+        "_npm": attr.label(
+            default = Label("@nodejs//:npm"),
             allow_files = True
         ),
     },


### PR DESCRIPTION
## What is the goal of this PR?

As migration to latest `@build_bazel_rules_nodejs` is planned, we need to adapt `assemble_npm`/`deploy_npm` to newest rules [while also preserving compatibility with currently-used version].

## What are the changes implemented in this PR?

- Use `@nodejs//:npm` (compatible with both old and new `rules-nodejs`)
- Append `external/nodejs_<platform>_amd64/bin/` to `PATH` when invoking `npm`. Adding `/bin/` and `/usr/bin` is also required to have `bash`/`dirname` available (needed by `npm` script)
