### PR TITLE
Adapt deploy_npm to latest rules-nodejs

### DIFF
--- a/npm/templates/deploy.py
+++ b/npm/templates/deploy.py
@@ -132,7 +132,14 @@ subprocess.check_call([
     '--registry={}'.format(npm_registry),
     'deploy_npm_updated.tgz'
 ], env={
-    'PATH': os.path.realpath('external/nodejs/bin/nodejs/bin/')
+    'PATH': ':'.join([
+        '/usr/bin/',
+        '/bin/',
+        os.path.realpath('external/nodejs/bin/nodejs/bin/'),
+        os.path.realpath('external/nodejs_darwin_amd64/bin/'),
+        os.path.realpath('external/nodejs_linux_amd64/bin/'),
+        os.path.realpath('external/nodejs_windows_amd64/bin/'),
+    ])
 })
 
 os.remove('deploy_npm_updated.tgz')


### PR DESCRIPTION
## What is the goal of this PR?

Updated `rules-nodejs` change location of `npm`.

## What are the changes implemented in this PR?

Make `PATH` in invoking `npm` in `deploy_npm` same as `assemble_npm`