### PR TITLE
Quickfix to deploy_npm: properly set PATH

### DIFF
--- a/npm/templates/deploy.py
+++ b/npm/templates/deploy.py
@@ -105,7 +105,14 @@ with open(expect_input_file.name) as expect_input:
     subprocess.check_call([
         '/usr/bin/expect',
     ], stdin=expect_input, env={
-        'PATH': os.path.realpath('external/nodejs/bin/nodejs/bin/')
+        'PATH': ':'.join([
+            '/usr/bin/',
+            '/bin/',
+            os.path.realpath('external/nodejs/bin/nodejs/bin/'),
+            os.path.realpath('external/nodejs_darwin_amd64/bin/'),
+            os.path.realpath('external/nodejs_linux_amd64/bin/'),
+            os.path.realpath('external/nodejs_windows_amd64/bin/'),
+        ])
     })
 
 


### PR DESCRIPTION
## What is the goal of this PR?

Updated `rules-nodejs` change location of `npm`.

## What are the changes implemented in this PR?

Make `PATH` in invoking `npm` in `deploy_npm` same as `assemble_npm`