### PR TITLE
Fix npm target in assemble/deploy npm rules

### DIFF
--- a/npm/rules.bzl
+++ b/npm/rules.bzl
@@ -70,7 +70,7 @@ assemble_npm = rule(
             cfg = "host"
         ),
         "_npm": attr.label(
-            default = Label("@nodejs//:npm"),
+            default = Label("@nodejs//:bin/npm"),
             allow_files = True
         )
     },
@@ -130,7 +130,7 @@ deploy_npm = rule(
             default = "//common:common.py"
         ),
         "_npm": attr.label(
-            default = Label("@nodejs//:npm"),
+            default = Label("@nodejs//:bin/npm"),
             allow_files = True
         ),
     },


### PR DESCRIPTION
## What is the goal of this PR?

Fix `deploy_npm` rule implementation

## What are the changes implemented in this PR?

Use `npm` label that's compatible with both `assemble_npm` and `deploy_npm`
