### PR TITLE
Set default GCP image size to 20GB

### DIFF
--- a/gcp/packer.template.json
+++ b/gcp/packer.template.json
@@ -12,7 +12,8 @@
       "zone": "{zone}",
       "ssh_username": "ubuntu",
       "image_name": "{image_name}",
-      "image_licenses": ["{image_licenses}"]
+      "image_licenses": ["{image_licenses}"],
+      "disk_size": 20
     }
   ],
 


### PR DESCRIPTION
## What is the goal of this PR?

Fixes graknlabs/grakn-kgms#285

## What are the changes implemented in this PR?

Default image size for GCP deployments should be 20GB to avoid getting a warning
