### PR TITLE
Make workspace_refs optional for assemble_maven

### DIFF
--- a/maven/_pom_replace_version.py
+++ b/maven/_pom_replace_version.py
@@ -19,25 +19,33 @@
 # under the License.
 #
 
+import argparse
 import json
 import sys
 
-_, preprocessed_template_path, workspace_refs_path, version_file_path, pom_path = sys.argv
+parser = argparse.ArgumentParser()
+parser.add_argument('--template_file', type=argparse.FileType('rt'))
+parser.add_argument('--version_file', type=argparse.FileType('rt'))
+parser.add_argument('--pom_file', type=argparse.FileType('wt'))
+parser.add_argument('--workspace_refs', required=False, type=argparse.FileType('rt'))
+args = parser.parse_args()
 
-with open(preprocessed_template_path, 'r') as template_file, \
-        open(workspace_refs_path, 'r') as refs_file, \
-        open(version_file_path, 'r') as version_file, \
-        open(pom_path, 'w') as pom_file:
+refs = {
+    'commits': {},
+    'tags': {},
+}
 
-    refs = json.loads(refs_file.read().strip())
-    template = template_file.read().strip()
-    version = version_file.read().strip()
+if args.workspace_refs:
+    refs = json.loads(args.workspace_refs.read().strip())
 
-    pom = template
-    for workspace in refs['commits']:
-        pom = pom.replace(workspace, refs['commits'][workspace])
-    for workspace in refs['tags']:
-        pom = pom.replace(workspace, refs['tags'][workspace])
-    pom = pom.replace('{pom_version}', version)
+template = args.template_file.read().strip()
+version = args.version_file.read().strip()
 
-    pom_file.write(pom)
+pom = template
+for workspace in refs['commits']:
+    pom = pom.replace(workspace, refs['commits'][workspace])
+for workspace in refs['tags']:
+    pom = pom.replace(workspace, refs['tags'][workspace])
+pom = pom.replace('{pom_version}', version)
+
+args.pom_file.write(pom)


### PR DESCRIPTION
## What is the goal of this PR?

Fix #176
`assemble_maven` should support a scenario where `workspace_refs` is not provided by users

## What are the changes implemented in this PR?

* Default to empty `workspace_refs` if no file is provided