### PR TITLE
Fix RPM package name

### DIFF
--- a/rpm/rules.bzl
+++ b/rpm/rules.bzl
@@ -67,6 +67,7 @@ def assemble_rpm(name,
         symlinks: mapping between source and target of symbolic links
                     created at installation
     """
+    tag = "rpm_package_name={}".format(spec_file.split(':')[-1].replace('.spec', ''))
     tar_name = "_{}-rpm-tar".format(package_name)
 
     rpm_data = []
@@ -140,7 +141,6 @@ def assemble_rpm(name,
             "//conditions:default": ""
         })
     )
-    tag = "rpm_package_name={}".format(spec_file.split(':')[-1].replace('.spec', ''))
 
     native.genrule(
         name = name,


### PR DESCRIPTION
## What is the goal of this PR?

Fix #180 
If `workspace_refs` was passed to `assemble_rpm`, RPM package name would be invalid.

## What are the changes implemented in this PR?

`tag` which is attached to indicate RPM package name should be attached _before_ spec file is modified.
