### PR TITLE
Refactor how version is provided for distribution archives

### DIFF
--- a/common/assemble-versioned.py
+++ b/common/assemble-versioned.py
@@ -32,13 +32,13 @@ target_paths = sys.argv[3:]
 
 version = open(version_path, 'r').read().strip()
 
-with common.ZipFile(output_path, 'w', compression=zipfile.ZIP_DEFLATED) as output:
+with common.ZipFile(output_path, 'w', compression=zipfile.ZIP_STORED) as output:
     for target in sorted(target_paths):
-        if target.endswith('zip'):
-            zip = common.zip_repackage_with_version(target, version)
-            output.write(zip, os.path.basename(zip))
-        elif target.endswith('tar.gz'):
-            tar = common.tar_repackage_with_version(target, version)
-            output.write(tar, os.path.basename(tar))
+        if target.endswith('zip') or target.endswith('tar.gz'):
+            path_components = os.path.basename(target).split('.')
+            original_zip_basedir = path_components[0]
+            extension = '.'.join(path_components[1:])
+            repackaged_archive_fn = '{}-{}.{}'.format(original_zip_basedir, version, extension)
+            output.write(target, repackaged_archive_fn)
         else:
             raise ValueError('This file is neither a zip nor a tar.gz: {}'.format(target))

--- a/common/rules.bzl
+++ b/common/rules.bzl
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-load("@bazel_tools//tools/build_defs/pkg:pkg.bzl", "pkg_tar", "pkg_deb")
+load("@rules_pkg//:pkg.bzl", "pkg_tar", "pkg_deb")
 load("@graknlabs_bazel_distribution//common:java_deps.bzl", _java_deps = "java_deps")
 load("@graknlabs_bazel_distribution//common:tgz2zip.bzl", _tgz2zip = "tgz2zip")
 load("@graknlabs_bazel_distribution//common:checksum.bzl", _checksum = "checksum")
@@ -29,6 +29,30 @@ tgz2zip = _tgz2zip
 checksum = _checksum
 assemble_versioned = _assemble_versioned
 
+
+def _assemble_targz_package_dir_file_impl(ctx):
+    version = ctx.var.get('version', '')
+
+    package_dir = ctx.attr.package_dir
+    if package_dir and version:
+        package_dir = '{}-{}'.format(package_dir, version)
+
+    ctx.actions.run_shell(
+        inputs = [],
+        outputs = [ctx.outputs.package_dir_file],
+        command = "echo {} > {}".format(package_dir, ctx.outputs.package_dir_file.path)
+    )
+
+
+_assemble_targz_package_dir_file = rule(
+    attrs = {
+        "package_dir": attr.string()
+    },
+    outputs = {
+        "package_dir_file": "%{name}.package_dir"
+    },
+    implementation = _assemble_targz_package_dir_file_impl
+)
 
 def assemble_targz(name,
                    output_filename = None,
@@ -60,10 +84,15 @@ def assemble_targz(name,
         tags = tags,
     )
 
+    _assemble_targz_package_dir_file(
+        name = "{}__do_not_reference__pkgdir".format(name),
+        package_dir = output_filename
+    )
+
     pkg_tar(
         name = "{}__do_not_reference__targz_1".format(name),
         deps = [":{}__do_not_reference__targz_0".format(name)],
-        package_dir = output_filename,
+        package_dir_file = "{}__do_not_reference__pkgdir".format(name),
         extension = "tar.gz",
         tags = tags,
     )
@@ -79,6 +108,30 @@ def assemble_targz(name,
         tags = tags,
     )
 
+
+def _assemble_archive_prefix_file_impl(ctx):
+    version = ctx.var.get('version', '')
+
+    prefix = ctx.attr.prefix
+    if prefix and version:
+        prefix = '{}-{}'.format(prefix, version)
+
+    ctx.actions.run_shell(
+        inputs = [],
+        outputs = [ctx.outputs.prefix_file],
+        command = "echo {} > {}".format(prefix, ctx.outputs.prefix_file.path)
+    )
+
+
+_assemble_zip_prefix_file = rule(
+    attrs = {
+        "prefix": attr.string()
+    },
+    outputs = {
+        "prefix_file": "%{name}.prefix"
+    },
+    implementation = _assemble_archive_prefix_file_impl
+)
 
 def assemble_zip(name,
                  output_filename,
@@ -108,11 +161,16 @@ def assemble_zip(name,
         modes = permissions,
     )
 
+    _assemble_zip_prefix_file(
+        name = "{}__do_not_reference__prefix_file".format(name),
+        prefix = "./" + output_filename
+    )
+
     tgz2zip(
         name = name,
         tgz = ":{}__do_not_reference__targz".format(name),
         output_filename = output_filename,
-        prefix = "./" + output_filename,
+        prefix_file = "{}__do_not_reference__prefix_file".format(name),
         visibility = visibility
     )
 

--- a/common/tgz2zip.py
+++ b/common/tgz2zip.py
@@ -29,6 +29,12 @@ import tarfile
 
 _, tgz_fn, zip_fn, prefix = sys.argv
 
+if prefix.startswith('@'):
+    fn = prefix.replace('@', '')
+    with open(fn) as prefix_file:
+      prefix = prefix_file.read().strip()
+
+
 with tarfile.open(tgz_fn, mode='r:gz') as tgz:
     with zipfile.ZipFile(zip_fn, 'w', compression=zipfile.ZIP_DEFLATED) as zip:
         for tarinfo in sorted(tgz.getmembers(), key=lambda x: x.name):


### PR DESCRIPTION
## What is the goal of this PR?

Partial work on #150

Previously, we had to repack already-built `tar.gz` and `zip` distribution once again due to two reasons:
(1) - archive name doesn't have version in it (`grakn-core-all-linux.tar.gz` instead of `grakn-core-all-linux-1.5.9.tar.gz`)
(2) root folder _inside_ the archive didn't have version in it (`grakn-core-all-linux` instead of `grakn-core-all-linux-1.5.9`)

This pull request addresses (2).
Now, when `--define version=<>` is supplied during build time, it is used to construct root folder name inside the archive.

## What are the changes implemented in this PR?

* `pkg_tar` and `pkg_deb` are now loaded from `@rules_pkg` — version in `@bazel_tools` is going to be deprecated soon
* new rule `_assemble_targz_package_dir_file`: reads `package_file` from attributes and `version` from `--define version=<>` during build time; outputs a file which contains `package_file` and `version` separated by dash (if both are present). Output of this rule is later used as a root folder for `.tar.gz` package
* new rule `_assemble_zip_prefix_file`: reads `prefix` from attributes and `version` from `--define version=<>` during build time; outputs a file which contains `prefix` and `version` separated by dash (if both are present).  Output of this rule is later used as a root folder for `.zip` package. Additionally, `tgz2zip` rule is modified to be able to accept `prefix_file` [purpose is the same as `prefix`]
* `assemble_versioned` rule no longer changes files _inside_ the archives — only renaming of archives themselves is done
* `assemble_versioned` rule no longer performs compression on archive it generated (`ZIP_STORED` instead of `ZIP_DEFLATED`). While generated archive takes more space, build performance is 4x faster this way.

Please note: changes in invocation of `assemble_versioned` targets (as well as on targets which transitively depend on it, such as `deploy_github`) are needed. Specifically, they now have to be invoked as:

```
bazel run --define version=$(cat VERSION) //:deploy-github -- <old arguments>
```
