### PR TITLE
Makes part of `brew/templates/deploy.py` Python 3 compatible

### DIFF
--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -35,7 +35,7 @@ parse_deployment_properties = run_path('common.py')['parse_deployment_properties
 
 
 def get_distribution_url_from_formula(content):
-    url_line = filter(lambda l: l.lstrip().startswith('url'), content.split('\n'))[0]
+    url_line = filter(lambda l: l.lstrip().startswith('url'), content.split('\n')).next()
     url = url_line.strip().split(' ')[1].replace('"', '')
     return url
 


### PR DESCRIPTION
## What is the goal of this PR?
To make the `get_distribution_url_from_formula` method in `brew/templates/deploy.py`, compatible with Python 3.

## What are the changes implemented in this PR?
`filter` in Python 3 returns an iterator (not a list) and so we call `next()` on it to get its first element.
