### PR TITLE
Fix deploy_maven to be compatible with Python 3

### DIFF
--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -77,7 +77,7 @@ def upload(url, username, password, local_fn, remote_fn):
         '-u', '{}:{}'.format(username, password),
         '--upload-file', local_fn,
         urljoin(url, remote_fn)
-    ]).strip()
+    ]).decode().strip()
 
     if upload_status_code != '201':
         raise Exception('upload of {} failed, got HTTP status code {}'.format(


### PR DESCRIPTION
## What is the goal of this PR?

`deploy_maven` was failing even when HTTP status code from uploading was successful.

## What are the changes implemented in this PR?

Decode output from `sp.check_output` so `str` is compared with `str`
