### PR TITLE
Bugfix hashlib invocations in deploy_brew and deploy_maven

### DIFF
--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -98,7 +98,7 @@ try:
         '--output',
         'distribution-github.zip'
     ])
-    checksum_of_distribution_github = hashlib.sha256(open('distribution-github.zip').read()).hexdigest()
+    checksum_of_distribution_github = hashlib.sha256(open('distribution-github.zip', 'rb').read()).hexdigest()
     if checksum_of_distribution_local != checksum_of_distribution_github:
         print('Error - unable to proceed with deploying to brew! The checksums do not match:')
         print('- The checksum of local distribution: {}'.format(checksum_of_distribution_local))

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -39,11 +39,11 @@ parse_deployment_properties = run_path('common.py')['parse_deployment_properties
 
 
 def sha1(fn):
-    return hashlib.sha1(open(fn).read()).hexdigest()
+    return hashlib.sha1(open(fn, 'rb').read()).hexdigest()
 
 
 def md5(fn):
-    return hashlib.md5(open(fn).read()).hexdigest()
+    return hashlib.md5(open(fn, 'rb').read()).hexdigest()
 
 
 def update_pom_within_jar(jar_path, new_pom_content):


### PR DESCRIPTION
## What is the goal of this PR?

`deploy_brew` and `deploy_maven` were non-operational due to incorrect usage of `hashlib`

## What are the changes implemented in this PR?

`hashlib.<algo>` expects `bytes` to calculate checksum of, so we open files in "read binary" (`rb`) mode
