### PR TITLE
Refactor how version is provided for Maven deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Assemble Java package for subsequent deployment to Maven repo
     <tr id="assemble_maven-workspace_refs">
       <td><code>workspace_refs</code></td>
       <td>
-        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
         <p>
           JSON file describing dependencies to other Bazel workspaces
         </p>
@@ -978,7 +978,7 @@ Packs Java library alongside with its dependencies into archive
 ## tgz2zip
 
 <pre>
-tgz2zip(<a href="#tgz2zip-name">name</a>, <a href="#tgz2zip-output_filename">output_filename</a>, <a href="#tgz2zip-prefix">prefix</a>, <a href="#tgz2zip-tgz">tgz</a>)
+tgz2zip(<a href="#tgz2zip-name">name</a>, <a href="#tgz2zip-output_filename">output_filename</a>, <a href="#tgz2zip-prefix">prefix</a>, <a href="#tgz2zip-prefix_file">prefix_file</a>, <a href="#tgz2zip-tgz">tgz</a>)
 </pre>
 
 Converts .tar.gz into .zip
@@ -1015,6 +1015,15 @@ Converts .tar.gz into .zip
         String; optional
         <p>
           Prefix of files in archive
+        </p>
+      </td>
+    </tr>
+    <tr id="tgz2zip-prefix_file">
+      <td><code>prefix_file</code></td>
+      <td>
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
+        <p>
+          Prefix of files in archive (as a file)
         </p>
       </td>
     </tr>

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -46,30 +46,6 @@ def md5(fn):
     return hashlib.md5(open(fn, 'rb').read()).hexdigest()
 
 
-def update_pom_within_jar(jar_path, new_pom_content):
-    ext = 'jar'
-    original_jar_basename = os.path.basename(jar_path[:-len(ext) - 1])
-    updated_jar_basename = original_jar_basename + '-updated'
-    updated_jar_path = updated_jar_basename + '.' + ext
-    with zipfile.ZipFile(jar_path, 'r') as original_jar, \
-            zipfile.ZipFile(updated_jar_path, 'w', compression=zipfile.ZIP_DEFLATED) as updated_jar:
-        for orig_info in sorted(original_jar.infolist(), key=lambda info: info.filename):
-            repkg_name = orig_info.filename
-            repkg_content = ''
-            if not orig_info.filename.endswith('/'):
-                if os.path.basename(orig_info.filename) == 'pom.xml':
-                    repkg_content = new_pom_content
-                else:
-                    repkg_content = original_jar.read(orig_info)
-            repkg_info = zipfile.ZipInfo(repkg_name)
-            repkg_info.compress_type = zipfile.ZIP_DEFLATED
-            repkg_info.external_attr = orig_info.external_attr
-            repkg_info.date_time = orig_info.date_time
-            updated_jar.writestr(repkg_info, repkg_content)
-
-    return updated_jar_path
-
-
 def upload(url, username, password, local_fn, remote_fn):
     upload_status_code = sp.check_output([
         'curl', '--silent', '--output', '/dev/stderr',
@@ -100,15 +76,15 @@ def sign(fn):
     return asc_file
 
 
-def unpack_args(_, a, b, c=False):
-    return a, b, c == '--gpg'
+def unpack_args(_, a, b=False):
+    return a, b == '--gpg'
 
 
-if len(sys.argv) < 3:
-    raise ValueError('Should pass <snapshot|release> <version> [--gpg] as arguments')
+if len(sys.argv) < 2:
+    raise ValueError('Should pass <snapshot|release> [--gpg] as arguments')
 
 
-repo_type, version, should_sign = unpack_args(*sys.argv)
+repo_type, should_sign = unpack_args(*sys.argv)
 
 username, password = os.getenv('DEPLOY_MAVEN_USERNAME'), os.getenv('DEPLOY_MAVEN_PASSWORD')
 
@@ -118,10 +94,31 @@ if not username:
 if not password:
     raise ValueError('Error: password should be passed via $DEPLOY_MAVEN_PASSWORD env variable')
 
+deployment_properties = parse_deployment_properties('deployment.properties')
+maven_url = deployment_properties['repo.maven.' + repo_type]
+jar_path = "$JAR_PATH"
+pom_file_path = "$POM_PATH"
+srcjar_path = "$SRCJAR_PATH"
+
+namespace = { 'namespace': 'http://maven.apache.org/POM/4.0.0' }
+root = ElementTree.parse(pom_file_path).getroot()
+group_id = root.find('namespace:groupId', namespace)
+artifact_id = root.find('namespace:artifactId', namespace)
+version = root.find('namespace:version', namespace)
+if group_id is None or len(group_id.text) == 0:
+    raise Exception("Could not get groupId from pom.xml")
+if artifact_id is None or len(artifact_id.text) == 0:
+    raise Exception("Could not get artifactId from pom.xml")
+if version is None or len(version.text) == 0:
+    raise Exception("Could not get version from pom.xml")
+
+version = version.text
+
 repo_type_snapshot = 'snapshot'
 version_snapshot_regex = '^[0-9|a-f|A-F]{40}$'
 repo_type_release = 'release'
 version_release_regex = '^[0-9]+.[0-9]+.[0-9]+$'
+
 if repo_type not in [repo_type_snapshot, repo_type_release]:
     raise ValueError("Invalid repository type: {}. It should be one of these: {}"
                      .format(repo_type, [repo_type_snapshot, repo_type_release]))
@@ -134,68 +131,40 @@ if repo_type == 'release' and len(re.findall(version_release_regex, version)) ==
                      'must have a version which complies to this regex: {}'
                      .format(version, repo_type, version_snapshot_regex))
 
-deployment_properties = parse_deployment_properties('deployment.properties')
-maven_url = deployment_properties['repo.maven.' + repo_type]
-jar_path = "$JAR_PATH"
-pom_file_path = "$POM_PATH"
-srcjar_path = "$SRCJAR_PATH"
-
-namespace = { 'namespace': 'http://maven.apache.org/POM/4.0.0' }
-root = ElementTree.parse(pom_file_path).getroot()
-group_id = root.find('namespace:groupId', namespace)
-artifact_id = root.find('namespace:artifactId', namespace)
-version_placeholder = root.find('namespace:version', namespace)
-if group_id is None or len(group_id.text) == 0:
-    raise Exception("Could not get groupId from pom.xml")
-if artifact_id is None or len(artifact_id.text) == 0:
-    raise Exception("Could not get artifactId from pom.xml")
-if version_placeholder is None or len(version_placeholder.text) == 0:
-    raise Exception("Could not get version from pom.xml")
-
 filename_base = '{coordinates}/{artifact}/{version}/{artifact}-{version}'.format(
     coordinates=group_id.text.replace('.', '/'), version=version, artifact=artifact_id.text)
 
-pom_updated = None
-jar_updated = None
-
-with open(pom_file_path, 'r') as pom_original, tempfile.NamedTemporaryFile(mode='wt', delete=False) as pom_updated:
-    pom_updated_content = pom_original.read().replace(version_placeholder.text, version)
-    pom_updated.write(pom_updated_content)
-    pom_updated.flush()
-    jar_updated = update_pom_within_jar(jar_path, pom_updated_content)
-    print('pom_updated = {}'.format(pom_updated.name))
-    print('jar_updated = {}'.format(jar_updated))
-    upload(maven_url, username, password, pom_updated.name, filename_base + '.pom')
-    if should_sign:
-        upload(maven_url, username, password, sign(pom_updated.name), filename_base + '.pom.asc')
-    upload(maven_url, username, password, jar_updated, filename_base + '.jar')
-    if should_sign:
-        upload(maven_url, username, password, sign(jar_updated), filename_base + '.jar.asc')
-    upload(maven_url, username, password, srcjar_path, filename_base + '-sources.jar')
-    if should_sign:
-        upload(maven_url, username, password, sign(srcjar_path), filename_base + '-sources.jar.asc')
-    # TODO(vmax): use real Javadoc instead of srcjar
-    upload(maven_url, username, password, srcjar_path, filename_base + '-javadoc.jar')
-    if should_sign:
-        upload(maven_url, username, password, sign(srcjar_path), filename_base + '-javadoc.jar.asc')
+upload(maven_url, username, password, pom_file_path.name, filename_base + '.pom')
+if should_sign:
+    upload(maven_url, username, password, sign(pom_file_path.name), filename_base + '.pom.asc')
+upload(maven_url, username, password, jar_path, filename_base + '.jar')
+if should_sign:
+    upload(maven_url, username, password, sign(jar_path), filename_base + '.jar.asc')
+upload(maven_url, username, password, srcjar_path, filename_base + '-sources.jar')
+if should_sign:
+    upload(maven_url, username, password, sign(srcjar_path), filename_base + '-sources.jar.asc')
+# TODO(vmax): use real Javadoc instead of srcjar
+upload(maven_url, username, password, srcjar_path, filename_base + '-javadoc.jar')
+if should_sign:
+    upload(maven_url, username, password, sign(srcjar_path), filename_base + '-javadoc.jar.asc')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True) as pom_md5:
-    pom_md5.write(md5(pom_updated.name))
+    pom_md5.write(md5(pom_file_path.name))
     pom_md5.flush()
     upload(maven_url, username, password, pom_md5.name, filename_base + '.pom.md5')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True) as pom_sha1:
-    pom_sha1.write(sha1(pom_updated.name))
+    pom_sha1.write(sha1(pom_file_path.name))
     pom_sha1.flush()
     upload(maven_url, username, password, pom_sha1.name, filename_base + '.pom.sha1')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True) as jar_md5:
-    jar_md5.write(md5(jar_updated))
+    jar_md5.write(md5(jar_path))
     jar_md5.flush()
     upload(maven_url, username, password, jar_md5.name, filename_base + '.jar.md5')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True) as jar_sha1:
-    jar_sha1.write(sha1(jar_updated))
+    jar_sha1.write(sha1(jar_path))
     jar_sha1.flush()
     upload(maven_url, username, password, jar_sha1.name, filename_base + '.jar.sha1')
 


### PR DESCRIPTION
## What is the goal of this PR?

Partial work on #150

## What are the changes implemented in this PR?

- `deploy_maven` no longer accepts version as command-line argument. Additionally, it no longer modifies `pom.xml` and `jar` which are to be deployed. Instead, it assumes that dependent `assemble_maven` target is already properly versioned by providing `--define version=<VERSION>`
- chore: regenerate docs
