### PR TITLE
Refactor how version is provided for assemble_npm rule

### DIFF
--- a/npm/rules.bzl
+++ b/npm/rules.bzl
@@ -25,6 +25,10 @@ def _assemble_npm_impl(ctx):
         version_file = ctx.actions.declare_file(ctx.attr.name + "__do_not_reference.version")
         version = ctx.var.get('version', '0.0.0')
 
+        if len(version) == 40:
+            # this is a commit SHA, most likely
+            version = "0.0.0-{}".format(version)
+
         ctx.actions.run_shell(
             inputs = [],
             outputs = [version_file],


### PR DESCRIPTION
## What is the goal of this PR?

Partial work on #150

## What are the changes implemented in this PR?

* `deploy_npm` no longer modifies the archive provided by `assemble_npm` if `repo_type` is `snapshot`. Instead, it assumes archive generated by `assemble_npm`  already contains correct version.
* `assemble_npm` now prepends `0.0.0-` if version resembles a commit SHA
