### PR TITLE
Bugfix deploy_maven rule

### DIFF
--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -134,9 +134,9 @@ if repo_type == 'release' and len(re.findall(version_release_regex, version)) ==
 filename_base = '{coordinates}/{artifact}/{version}/{artifact}-{version}'.format(
     coordinates=group_id.text.replace('.', '/'), version=version, artifact=artifact_id.text)
 
-upload(maven_url, username, password, pom_file_path.name, filename_base + '.pom')
+upload(maven_url, username, password, pom_file_path, filename_base + '.pom')
 if should_sign:
-    upload(maven_url, username, password, sign(pom_file_path.name), filename_base + '.pom.asc')
+    upload(maven_url, username, password, sign(pom_file_path), filename_base + '.pom.asc')
 upload(maven_url, username, password, jar_path, filename_base + '.jar')
 if should_sign:
     upload(maven_url, username, password, sign(jar_path), filename_base + '.jar.asc')
@@ -149,12 +149,12 @@ if should_sign:
     upload(maven_url, username, password, sign(srcjar_path), filename_base + '-javadoc.jar.asc')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True) as pom_md5:
-    pom_md5.write(md5(pom_file_path.name))
+    pom_md5.write(md5(pom_file_path))
     pom_md5.flush()
     upload(maven_url, username, password, pom_md5.name, filename_base + '.pom.md5')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True) as pom_sha1:
-    pom_sha1.write(sha1(pom_file_path.name))
+    pom_sha1.write(sha1(pom_file_path))
     pom_sha1.flush()
     upload(maven_url, username, password, pom_sha1.name, filename_base + '.pom.sha1')
 


### PR DESCRIPTION
## What is the goal of this PR?

Recent changes to `deploy_maven` broke it, causing to throw an exception of these kind:
```
Traceback (most recent call last):
  File "/home/circleci/.cache/bazel/_bazel_circleci/b86ecb3d15acddc9ce11cf216fed02f7/execroot/graknlabs_client_java/bazel-out/k8-fastbuild/bin/deploy.py", line 137, in <module>
    upload(maven_url, username, password, pom_file_path.name, filename_base + '.pom')
AttributeError: 'str' object has no attribute 'name'
```
This PR addresses this

## What are the changes implemented in this PR?

Treat `pom_file_path` as `str` so exception is not thrown.
