### PR TITLE
Bugfix tgz2zip to produce archives compatible with Windows

### DIFF
--- a/common/tgz2zip.py
+++ b/common/tgz2zip.py
@@ -40,7 +40,7 @@ with tarfile.open(tgz_fn, mode='r:gz') as tgz:
         for tarinfo in sorted(tgz.getmembers(), key=lambda x: x.name):
             f = ''
             is_dir = tarinfo.isdir()
-            name = './' + os.path.normpath(os.path.join(prefix, tarinfo.name))
+            name = os.path.normpath(os.path.join(prefix, tarinfo.name))
             if not is_dir:
                 f = tgz.extractfile(tarinfo).read()
             else:


### PR DESCRIPTION
## What is the goal of this PR?

Fix graknlabs/grakn#5108

## What are the changes implemented in this PR?

Archives previously produced by `assemble_zip` (underlying rule `tgz2zip`) were not compatible with Windows (Windows Explorer failed to unpack them). As pointed out by experiment, error was caused by having `./` prefix in archive entries. This PR removes the prefix from every ZIP entry.