### PR TITLE
Make dependency on setuptools stricter

### DIFF
--- a/pip/requirements.txt
+++ b/pip/requirements.txt
@@ -8,7 +8,7 @@ pkginfo==1.5.0.1
 readme-renderer==24.0
 requests-toolbelt==0.8.0
 requests==2.21.0
-setuptools>=38.6.0
+setuptools==38.6.0
 tqdm==4.29.1
 twine==1.12.1
 urllib3==1.24.1


### PR DESCRIPTION
## What is the goal of this PR?

Recently,  a problem in`assemble_pip` was discovered:
```
  File "/home/********/.cache/bazel/_bazel_********/a3bf690c4bacc2f8a31e33bc35f6090b/sandbox/linux-sandbox/191/execroot/graknlabs_client_python/bazel-out/host/bin/external/graknlabs_bazel_distribution/pip/assemble.runfiles/pypi__setuptools_45_0_0/pkg_resources/__init__.py", line 93, in <module>
    raise RuntimeError("Python 3.5 or later is required")
RuntimeError: Python 3.5 or later is required
```

Given that we are still using Python 2 to build and test `client-python`, we need to downgrade `setuptools` to a supported version

## What are the changes implemented in this PR?

Depend on exact version of `setuptools` in `pip/requirements.txt`
