### PR TITLE
Improve configurability of assemble_gcp rule

### DIFF
--- a/gcp/packer.template.json
+++ b/gcp/packer.template.json
@@ -12,6 +12,7 @@
       "zone": "{zone}",
       "ssh_username": "ubuntu",
       "image_name": "{image_name}",
+      "image_family": "{image_family}",
       "image_licenses": {image_licenses},
       "disk_size": 20
     }

--- a/gcp/packer.template.json
+++ b/gcp/packer.template.json
@@ -8,11 +8,11 @@
       "type": "googlecompute",
       "account_file": "{{user `gcp_account_file`}}",
       "project_id": "{project_id}",
-      "source_image_family": "ubuntu-1604-lts",
+      "source_image_family": "{source_image_family}",
       "zone": "{zone}",
       "ssh_username": "ubuntu",
       "image_name": "{image_name}",
-      "image_licenses": ["{image_licenses}"],
+      "image_licenses": {image_licenses},
       "disk_size": 20
     }
   ],

--- a/gcp/rules.bzl
+++ b/gcp/rules.bzl
@@ -26,7 +26,7 @@ def assemble_gcp(name,
                  install,
                  zone,
                  image_name,
-                 files,
+                 files=None,
                  image_licenses=None,
                  source_image_family="ubuntu-1604-lts"):
     """Assemble files for GCP deployment
@@ -41,6 +41,8 @@ def assemble_gcp(name,
         image_licenses: licenses to attach to deployed image
         source_image_family: Family of GCP base image
     """
+    if not files:
+        files = {}
     install_fn = Label(install).name
     generated_config_target_name = name + "__do_not_reference_config"
     generate_json_config(

--- a/gcp/rules.bzl
+++ b/gcp/rules.bzl
@@ -26,8 +26,9 @@ def assemble_gcp(name,
                  install,
                  zone,
                  image_name,
-                 image_licenses,
-                 files):
+                 files,
+                 image_licenses=None,
+                 source_image_family="ubuntu-1604-lts"):
     """Assemble files for GCP deployment
 
     Args:
@@ -36,8 +37,9 @@ def assemble_gcp(name,
         install: Bazel label for install file
         zone: GCP zone to deploy image to
         image_name: name of deployed image
-        image_licenses: licenses to attach to deployed image
         files: Files to include into GCP deployment
+        image_licenses: licenses to attach to deployed image
+        source_image_family: Family of GCP base image
     """
     install_fn = Label(install).name
     generated_config_target_name = name + "__do_not_reference_config"
@@ -48,8 +50,9 @@ def assemble_gcp(name,
             "{project_id}": project_id,
             "{zone}": zone,
             "{image_name}": image_name,
-            "{image_licenses}": image_licenses,
-            "{install}": install_fn
+            "{image_licenses}": "[\"{}\"]".format(image_licenses) if image_licenses else "[]",
+            "{install}": install_fn,
+            "{source_image_family}": source_image_family,
         }
     )
     files[install] = install_fn

--- a/gcp/rules.bzl
+++ b/gcp/rules.bzl
@@ -26,6 +26,7 @@ def assemble_gcp(name,
                  install,
                  zone,
                  image_name,
+                 image_family="",
                  files=None,
                  image_licenses=None,
                  source_image_family="ubuntu-1604-lts"):
@@ -37,6 +38,7 @@ def assemble_gcp(name,
         install: Bazel label for install file
         zone: GCP zone to deploy image to
         image_name: name of deployed image
+        image_family: family of deployed image
         files: Files to include into GCP deployment
         image_licenses: licenses to attach to deployed image
         source_image_family: Family of GCP base image
@@ -52,6 +54,7 @@ def assemble_gcp(name,
             "{project_id}": project_id,
             "{zone}": zone,
             "{image_name}": image_name,
+            "{image_family}": image_family,
             "{image_licenses}": "[\"{}\"]".format(image_licenses) if image_licenses else "[]",
             "{install}": install_fn,
             "{source_image_family}": source_image_family,


### PR DESCRIPTION
## What is the goal of this PR?

Improve configurability of `assemble_gcp` for our newly-discovered usecases

## What are the changes implemented in this PR?

- Make `image_licenses` optional
- Make `source_image_family` configurable
- Make `files` optional
- Make `image_family` configurable