### PR TITLE
Adding Scala and multiple POM files support.

### DIFF
--- a/maven/templates/rules.bzl
+++ b/maven/templates/rules.bzl
@@ -162,9 +162,9 @@ def _parse_maven_coordinates(coordinate_string):
 
 def _generate_pom_xml(ctx, maven_coordinates):
     # Final 'pom.xml' is generated in 2 steps
-    preprocessed_template = ctx.actions.declare_file("_pom.xml")
+    preprocessed_template = ctx.actions.declare_file("_{}_pom.xml".format(ctx.attr.name))
 
-    pom_file = ctx.actions.declare_file("pom.xml")
+    pom_file = ctx.actions.declare_file("{}_pom.xml".format(ctx.attr.name))
 
     maven_pom_deps = ctx.attr.target[MavenPomInfo].maven_pom_deps
     deps_coordinates = depset(maven_pom_deps).to_list()
@@ -257,18 +257,23 @@ def _generate_pom_xml(ctx, maven_coordinates):
 
 def _assemble_maven_impl(ctx):
     target = ctx.attr.target
-    target_string = target[JavaLibInfo].target_coordinates.to_list()[0]
+    target_string = target[JavaLibInfo].target_coordinates.to_list()[-1]
 
     maven_coordinates = _parse_maven_coordinates(target_string)
 
     pom_file = _generate_pom_xml(ctx, maven_coordinates)
 
     # there is also .source_jar which produces '.srcjar'
-    if hasattr(target, "java"):
-        jar = target[JavaInfo].outputs.jars[0].class_jar
-        srcjar = target[JavaInfo].outputs.jars[0].source_jar
-    elif hasattr(target, "files"):
-        jar = target.files.to_list()[0]
+    srcjar = None
+
+    if hasattr(target, "files") and target.files.to_list() and target.files.to_list()[0].extension == 'jar':
+        all_jars = target[JavaInfo].outputs.jars
+        jar = all_jars[0].class_jar
+
+        for output in all_jars:
+            if output.source_jar.basename.endswith('-src.jar'):
+                srcjar = output.source_jar
+                break
     else:
         fail("Could not find JAR file to deploy in {}".format(target))
 
@@ -281,10 +286,16 @@ def _assemble_maven_impl(ctx):
         executable = ctx.executable._assemble_script,
     )
 
-    return [
-        DefaultInfo(files = depset([output_jar, pom_file, srcjar])),
-        MavenDeploymentInfo(jar = output_jar, pom = pom_file, srcjar = srcjar)
-    ]
+    if srcjar == None:
+        return [
+            DefaultInfo(files = depset([output_jar, pom_file])),
+            MavenDeploymentInfo(jar = output_jar, pom = pom_file)
+        ]
+    else:
+        return [
+            DefaultInfo(files = depset([output_jar, pom_file, srcjar])),
+            MavenDeploymentInfo(jar = output_jar, pom = pom_file, srcjar = srcjar)
+        ]
 
 assemble_maven = rule(
     attrs = {
@@ -364,7 +375,7 @@ def _deploy_maven_impl(ctx):
 
     lib_jar_link = "lib.jar"
     src_jar_link = "lib.srcjar"
-    pom_xml_link = "pom.xml"
+    pom_xml_link = ctx.attr.target[MavenDeploymentInfo].pom.basename
 
     ctx.actions.expand_template(
         template = ctx.file._deployment_script,
@@ -397,6 +408,7 @@ _default_deployment_properties = None if 'deployment_properties_placeholder' in 
 deploy_maven = rule(
     attrs = {
         "target": attr.label(
+            mandatory = True,
             providers = [MavenDeploymentInfo],
             doc = "assemble_maven target to deploy"
         ),


### PR DESCRIPTION
## What is the goal of this PR?

Fixing four issues:

1. I'm also using Scala here, which is almost identical in deployment to Java. However, using [scala_library](https://github.com/bazelbuild/rules_scala/blob/master/docs/scala_library.md) with `assemble_maven` doesn't work. 

2. The POM file name is hard-coded (`pom.xml`). Because we use both Scala and Java in the same BUILD file, the file was getting overwrite. #215 

3. Targets that have only the `files` attribute failed to run because the provider return `srcjar` when there's isn't any defined. #214 

4. `target_coordinates` is hard-coded to `[0]`, and it's not working on all cases.

There's another thing to consider here it seems. When using exports, I had problem with:

target_string = target[JavaLibInfo].target_coordinates.to_list()[-1]

The first element in the array was the export, and not the root target itself. It seems like [-1] worked better on couple of scenario I tested it again, but it's probably better to write a logic to pick the right target instead of guessing.

## What are the changes implemented in this PR?
- `pom.xml` will now be named based on the target name. So if my `assemble_maven` target name is `hello_world`, the pom is called `hello_world_pom.xml`.

- Side effect of the above is that now `deploy_maven` requires a target (it was optional). The reason for that is because `pom.xml` was hard-coded into `deploy_maven`. Now the unique pom file name is being grabbed from the Target directly.

- I changed the if condition that extracts jars and srcjars. First I'm checking the target has `files` attribute in it. If it does, I'm checking that there's files in `files`, and lastly I check the first file has JAR file in it (like you previously did). I also modified the way srcjars are being picked. I'm looking for `-src.jar` ending exclusively (the previous code was picking the first file in the list, and it wasn't the right srcjar using `scala_library` targets). 

- Srcjar is not available on all jars. In case there is no srcjar, the Provider no longer return it (it used to fail here).

- When using exports, the first item in the `target_coordinates` array is not the root target (`target_string = target[JavaLibInfo].target_coordinates.to_list()[0]`. It seems like [-1] worked better on couple of scenario I tested it again (as the root target was always the last in the list), but it's probably better to write a logic to pick the right target instead of guessing.

## Notes
I tested it on my Bazel project. I didn't find any tests to run the code changes on, so it's probably a good idea to try to run it on your Bazel projects to make sure it didn't break anything I wasn't aware of.

Thanks.