### PR TITLE
Bugfix assemble_maven: skip leaves representing JAR files

### DIFF
--- a/maven/templates/rules.bzl
+++ b/maven/templates/rules.bzl
@@ -110,6 +110,8 @@ def _maven_pom_deps_impl(_target, ctx):
         getattr(ctx.rule.attr, "runtime_deps", [])
 
     for dep in deps:
+        if dep.label.name.endswith('.jar'):
+            continue
         if dep.label.package.startswith(ctx.attr.package):
             deps_coordinates += dep[MavenPomInfo].maven_pom_deps
 


### PR DESCRIPTION
## What is the goal of this PR?

Previously, `assemble_maven` (with `package=""`) would fail with this error message:
```
<input file target @io-opencensus-opencensus-contrib-grpc-metrics//jar:io-opencensus-opencensus-contrib-grpc-metrics.jar> doesn't contain declared provider 'MavenPomInfo'
ERROR: Analysis of target '//:assemble-maven' failed; build aborted: Analysis of target '@io-opencensus-opencensus-contrib-grpc-metrics//jar:jar' failed; build aborted
```

## What are the changes implemented in this PR?

### Reasoning behind the fix

Part of the dependency graph:
```
<merged target @org-codehaus-mojo-animal-sniffer-annotations//jar:jar> -> [<input file target @org-codehaus-mojo-animal-sniffer-annotations//jar:org-codehaus-mojo-animal-sniffer-annotations.jar>]
```

`@org-codehaus-mojo-animal-sniffer-annotations//jar` is a target that has `maven_coordinate` tag that we need. However, when transitively propogating to its dependency, `@org-codehaus-mojo-animal-sniffer-annotations//jar:org-codehaus-mojo-animal-sniffer-annotations.jar`, Bazel don't see tags attached and fails. Therefore, we want to cutoff our traversal at .jar files

### Fix itself

Cutoff traversal for target with names ending in `.jar`