### PR TITLE
Allow disabling default service account for assemble_gcp

### DIFF
--- a/gcp/packer.template.json
+++ b/gcp/packer.template.json
@@ -14,7 +14,8 @@
       "image_name": "{image_name}",
       "image_family": "{image_family}",
       "image_licenses": {image_licenses},
-      "disk_size": 20
+      "disk_size": 20,
+      "disable_default_service_account": {disable_default_service_account}
     }
   ],
 

--- a/gcp/rules.bzl
+++ b/gcp/rules.bzl
@@ -29,6 +29,7 @@ def assemble_gcp(name,
                  image_family="",
                  files=None,
                  image_licenses=None,
+                 disable_default_service_account=False,
                  source_image_family="ubuntu-1604-lts"):
     """Assemble files for GCP deployment
 
@@ -41,6 +42,7 @@ def assemble_gcp(name,
         image_family: family of deployed image
         files: Files to include into GCP deployment
         image_licenses: licenses to attach to deployed image
+        disable_default_service_account: disable default service account
         source_image_family: Family of GCP base image
     """
     if not files:
@@ -58,6 +60,7 @@ def assemble_gcp(name,
             "{image_licenses}": "[\"{}\"]".format(image_licenses) if image_licenses else "[]",
             "{install}": install_fn,
             "{source_image_family}": source_image_family,
+            "{disable_default_service_account}": str(disable_default_service_account).lower()
         }
     )
     files[install] = install_fn


### PR DESCRIPTION
## What is the goal of this PR?

Previously, `packer` always attached a default service account to GCP instance it created. In case it did not exist it failed with a timeout and cryptic error message.

## What are the changes implemented in this PR?

Allow to create instances without a service account attached (which is fine if you're not doing any calls to GCP APIs during image creation)
