### PR TITLE
Implement assemble_azure rule

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -25,6 +25,7 @@ stardoc(
     out = "README.md",
     deps = [
         "//apt:lib",
+        "//azure:lib",
         "//aws:lib",
         "//brew:lib",
         "//common:lib",
@@ -37,6 +38,7 @@ stardoc(
         "//rpm:lib",
     ],
     symbol_names = [
+        "assemble_azure",
         "pkg_deb",
         "assemble_apt",
         "deploy_apt",

--- a/README.md
+++ b/README.md
@@ -1423,6 +1423,73 @@ Assemble files for AWS deployment
 </table>
 
 
+<a name="#assemble_azure"></a>
+
+## assemble_azure
+
+<pre>
+assemble_azure(<a href="#assemble_azure-name">name</a>, <a href="#assemble_azure-image_name">image_name</a>, <a href="#assemble_azure-resource_group_name">resource_group_name</a>, <a href="#assemble_azure-install">install</a>, <a href="#assemble_azure-files">files</a>)
+</pre>
+
+Assemble files for GCP deployment
+
+### Parameters
+
+<table class="params-table">
+  <colgroup>
+    <col class="col-param" />
+    <col class="col-description" />
+  </colgroup>
+  <tbody>
+    <tr id="assemble_azure-name">
+      <td><code>name</code></td>
+      <td>
+        required.
+        <p>
+          A unique name for this target.
+        </p>
+      </td>
+    </tr>
+    <tr id="assemble_azure-image_name">
+      <td><code>image_name</code></td>
+      <td>
+        required.
+        <p>
+          name of deployed image
+        </p>
+      </td>
+    </tr>
+    <tr id="assemble_azure-resource_group_name">
+      <td><code>resource_group_name</code></td>
+      <td>
+        required.
+        <p>
+          name of the resource group to place image in
+        </p>
+      </td>
+    </tr>
+    <tr id="assemble_azure-install">
+      <td><code>install</code></td>
+      <td>
+        required.
+        <p>
+          Bazel label for install file
+        </p>
+      </td>
+    </tr>
+    <tr id="assemble_azure-files">
+      <td><code>files</code></td>
+      <td>
+        optional. default is <code>None</code>
+        <p>
+          Files to include into Azure deployment
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
 <a name="#assemble_gcp"></a>
 
 ## assemble_gcp

--- a/azure/BUILD
+++ b/azure/BUILD
@@ -1,0 +1,30 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+exports_files(["packer.template.json"])
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "lib",
+    srcs = [
+        "rules.bzl",
+    ],
+    visibility = ["//visibility:public"]
+)

--- a/azure/packer.template.json
+++ b/azure/packer.template.json
@@ -1,0 +1,40 @@
+{
+  "variables": {
+    "subscription_id": "{{env `DEPLOY_PACKER_AZURE_SUBSCRIPTION_ID`}}",
+    "client_id": "{{env `DEPLOY_PACKER_AZURE_CLIENT_ID`}}",
+    "client_secret": "{{env `DEPLOY_PACKER_AZURE_CLIENT_SECRET`}}",
+    "version": "{{env `DEPLOY_PACKER_VERSION`}}"
+  },
+  "builders": [
+    {
+      "type": "azure-arm",
+      "subscription_id": "{{user `subscription_id`}}",
+      "client_id": "{{user `client_id`}}",
+      "client_secret": "{{user `client_secret`}}",
+      "managed_image_name": "{image_name}",
+      "managed_image_resource_group_name": "{resource_group_name}",
+      "os_type": "Linux",
+      "image_publisher": "Canonical",
+      "image_offer": "UbuntuServer",
+      "image_sku": "18.04-LTS",
+      "build_resource_group_name": "{resource_group_name}",
+      "vm_size": "Standard_B2s"
+    }
+  ],
+
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": [ "mkdir /tmp/deployment" ]
+    },
+    {
+      "type": "file",
+      "source": "files/",
+      "destination": "/tmp/deployment/"
+    },
+    {
+      "type": "shell",
+      "inline": [ "sudo /tmp/deployment/{install}" ]
+    }
+  ]
+}

--- a/azure/rules.bzl
+++ b/azure/rules.bzl
@@ -1,0 +1,55 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+load("//packer:rules.bzl", "assemble_packer")
+load("//common:generate_json_config.bzl", "generate_json_config")
+
+def assemble_azure(name,
+                   image_name,
+                   resource_group_name,
+                   install,
+                   files=None):
+    """Assemble files for GCP deployment
+
+    Args:
+        name: A unique name for this target.
+        image_name: name of deployed image
+        resource_group_name: name of the resource group to place image in
+        install: Bazel label for install file
+        files: Files to include into Azure deployment
+    """
+    if not files:
+        files = {}
+    install_fn = Label(install).name
+    generated_config_target_name = name + "__do_not_reference_config"
+    generate_json_config(
+        name = generated_config_target_name,
+        template = "@graknlabs_bazel_distribution//azure:packer.template.json",
+        substitutions = {
+            "{image_name}": image_name,
+            "{resource_group_name}": resource_group_name,
+            "{install}": install_fn,
+        }
+    )
+    files[install] = install_fn
+    assemble_packer(
+        name = name,
+        config = generated_config_target_name,
+        files = files
+    )

--- a/doc_hub.bzl
+++ b/doc_hub.bzl
@@ -27,6 +27,9 @@ deploy_apt = d
 load("//aws:rules.bzl", _ = "assemble_aws")
 assemble_aws = _
 
+load("//azure:rules.bzl", _ = "assemble_azure")
+assemble_azure = _
+
 load("//brew:rules.bzl", _ = "deploy_brew")
 deploy_brew = _
 


### PR DESCRIPTION
## What is the goal of this PR?

Implement a rule for deployment Microsoft Azure machine images

## What are the changes implemented in this PR?

Implement `assemble_azure` macro. Sample usage:

`load("@graknlabs_bazel_distribution//azure:rules.bzl", "assemble_azure")`

```
assemble_azure(
    name = "assemble-azure-project",
    install = "//:install.sh",
    files = {
        "//:assemble-linux-targz": "archive.tar.gz",
    },
    image_name = "...",
    resource_group_name = "..."
)
```