### PR TITLE
Upgrade Azure base image to Ubuntu 20.04

### DIFF
--- a/azure/packer.template.json
+++ b/azure/packer.template.json
@@ -15,8 +15,8 @@
       "managed_image_resource_group_name": "{resource_group_name}",
       "os_type": "Linux",
       "image_publisher": "Canonical",
-      "image_offer": "UbuntuServer",
-      "image_sku": "18.04-LTS",
+      "image_offer": "0001-com-ubuntu-server-focal",
+      "image_sku": "20_04-lts",
       "build_resource_group_name": "{resource_group_name}",
       "vm_size": "Standard_B2s"
     }


### PR DESCRIPTION
## What is the goal of this PR?

In order to improve compatibility and stay up-to-date, Azure images produced by `assemble_azure` now are based on latest Ubuntu LTS at the time, 20.04. 

## What are the changes implemented in this PR?

Change base Azure image to Ubuntu Server 20.04 LTS
