### PR TITLE
Add deploy_distribution rule

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -36,6 +36,7 @@ stardoc(
         "//packer:lib",
         "//pip:lib",
         "//rpm:lib",
+        "//distribution:lib",
     ],
     symbol_names = [
         "assemble_azure",
@@ -68,6 +69,7 @@ stardoc(
         "assemble_pip",
         "deploy_pip",
         "assemble_rpm",
-        "deploy_rpm"
+        "deploy_rpm",
+        "deploy_distribution",
     ],
 )

--- a/README.md
+++ b/README.md
@@ -532,6 +532,75 @@ Deploy Homebrew (Caskroom) formula to Homebrew tap
 </table>
 
 
+<a name="#deploy_distribution"></a>
+
+## deploy_distribution
+
+<pre>
+deploy_distribution(<a href="#deploy_distribution-name">name</a>, <a href="#deploy_distribution-artifact_group">artifact_group</a>, <a href="#deploy_distribution-deployment_properties">deployment_properties</a>, <a href="#deploy_distribution-target">target</a>, <a href="#deploy_distribution-version_file">version_file</a>)
+</pre>
+
+Deploy archive target into a raw repo
+
+### Attributes
+
+<table class="params-table">
+  <colgroup>
+    <col class="col-param" />
+    <col class="col-description" />
+  </colgroup>
+  <tbody>
+    <tr id="deploy_distribution-name">
+      <td><code>name</code></td>
+      <td>
+        <a href="https://bazel.build/docs/build-ref.html#name">Name</a>; required
+        <p>
+          A unique name for this target.
+        </p>
+      </td>
+    </tr>
+    <tr id="deploy_distribution-artifact_group">
+      <td><code>artifact_group</code></td>
+      <td>
+        String; required
+        <p>
+          The group of the artifact.
+        </p>
+      </td>
+    </tr>
+    <tr id="deploy_distribution-deployment_properties">
+      <td><code>deployment_properties</code></td>
+      <td>
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
+        <p>
+          File containing repository url by `repo.distribution` key
+        </p>
+      </td>
+    </tr>
+    <tr id="deploy_distribution-target">
+      <td><code>target</code></td>
+      <td>
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; required
+        <p>
+          File to deploy to repo
+        </p>
+      </td>
+    </tr>
+    <tr id="deploy_distribution-version_file">
+      <td><code>version_file</code></td>
+      <td>
+        <a href="https://bazel.build/docs/build-ref.html#labels">Label</a>; optional
+        <p>
+          File containing version string.
+            Alternatively, pass --define version=VERSION to Bazel invocation.
+            Not specifying version at all defaults to '0.0.0'
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+
 <a name="#deploy_github"></a>
 
 ## deploy_github

--- a/distribution/BUILD
+++ b/distribution/BUILD
@@ -1,0 +1,28 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "lib",
+    srcs = [
+        "rules.bzl",
+    ],
+    visibility = ["//visibility:public"]
+)

--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -1,3 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 def _deploy_distribution_impl(ctx):
     _deploy_script = ctx.actions.declare_file("{}_deploy.py".format(ctx.attr.name))
 

--- a/distribution/rules.bzl
+++ b/distribution/rules.bzl
@@ -1,0 +1,80 @@
+def _deploy_distribution_impl(ctx):
+    _deploy_script = ctx.actions.declare_file("{}_deploy.py".format(ctx.attr.name))
+
+    version_file = ctx.actions.declare_file(ctx.attr.name + "__do_not_reference.version")
+    version = ctx.var.get('version', '0.0.0')
+
+    ctx.actions.run_shell(
+        inputs = [],
+        outputs = [version_file],
+        command = "echo {} > {}".format(version, version_file.path),
+    )
+    
+    ctx.actions.expand_template(
+        template = ctx.file._deploy_script,
+        output = _deploy_script,
+        substitutions = {
+            "{version_file}": version_file.short_path,
+            "{artifact_path}": ctx.file.target.short_path,
+            "{artifact_group}": ctx.attr.artifact_group,
+        },
+    )
+    files = [
+        ctx.file.target,
+        ctx.file.deployment_properties,
+        version_file,
+        ctx.file._common_py
+    ]
+
+    symlinks = {
+        "deployment.properties": ctx.file.deployment_properties,
+        "common.py": ctx.file._common_py,
+        'VERSION': version_file,
+    }
+
+    return DefaultInfo(
+        executable = _deploy_script,
+        runfiles = ctx.runfiles(
+            files = files,
+            symlinks = symlinks,
+        ),
+    )
+
+
+deploy_distribution = rule(
+    attrs = {
+        "target": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "File to deploy to repo",
+        ),
+        "deployment_properties": attr.label(
+            allow_single_file = True,
+            mandatory = True,
+            doc = "File containing repository url by `repo.distribution` key",
+        ),
+        "version_file": attr.label(
+            allow_single_file = True,
+            doc = """
+            File containing version string.
+            Alternatively, pass --define version=VERSION to Bazel invocation.
+            Not specifying version at all defaults to '0.0.0'
+            """,
+        ),
+        "artifact_group": attr.string(
+            mandatory = True,
+            doc = "The group of the artifact.",
+        ),
+        "_deploy_script": attr.label(
+            allow_single_file = True,
+            default = "//distribution/templates:deploy.py",
+        ),
+        "_common_py": attr.label(
+            allow_single_file = True,
+            default = "//common:common.py",
+        ),
+    },
+    executable = True,
+    implementation = _deploy_distribution_impl,
+    doc = "Deploy archive target into a raw repo",
+)

--- a/distribution/templates/BUILD
+++ b/distribution/templates/BUILD
@@ -1,0 +1,20 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+exports_files(["deploy.py"])

--- a/distribution/templates/deploy.py
+++ b/distribution/templates/deploy.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+from __future__ import print_function
+from xml.etree import ElementTree
+
+import hashlib
+import os
+import re
+import subprocess as sp
+import sys
+import tempfile
+import zipfile
+from posixpath import join as urljoin
+
+# usual importing is not possible because
+# this script and module with common functions
+# are at different directory levels in sandbox
+from runpy import run_path
+parse_deployment_properties = run_path('common.py')['parse_deployment_properties']
+
+
+def upload(url, username, password, local_fn, remote_fn):
+    upload_status_code = sp.check_output([
+        'curl', '--silent', '--output', '/dev/stderr',
+        '--write-out', '%{http_code}',
+        '-u', '{}:{}'.format(username, password),
+        '--upload-file', local_fn,
+        urljoin(url, remote_fn)
+    ]).decode().strip()
+
+    if upload_status_code != '201':
+        raise Exception('upload of {} failed, got HTTP status code {}'.format(
+            local_fn, upload_status_code))
+
+
+def unpack_args(_, a):
+    return a
+
+
+if len(sys.argv) < 2:
+    raise ValueError('Should pass <snapshot|release> as arguments')
+
+repo_type = unpack_args(*sys.argv)
+
+username, password = os.getenv('DEPLOY_DISTRIBUTION_USERNAME'), os.getenv('DEPLOY_DISTRIBUTION_PASSWORD')
+
+if not username:
+    raise ValueError('Error: username should be passed via $DEPLOY_DISTRIBUTION_USERNAME env variable')
+
+if not password:
+    raise ValueError('Error: password should be passed via $DEPLOY_DISTRIBUTION_PASSWORD env variable')
+
+deployment_properties = parse_deployment_properties('deployment.properties')
+distribution_url = deployment_properties['repo.distribution.' + repo_type]
+
+
+version = open("{version_file}", "r").read().strip()
+
+repo_type_snapshot = 'snapshot'
+version_snapshot_regex = '^[0-9|a-f|A-F]{40}$'
+repo_type_release = 'release'
+version_release_regex = '^[0-9]+.[0-9]+.[0-9]+$'
+
+if repo_type not in [repo_type_snapshot, repo_type_release]:
+    raise ValueError("Invalid repository type: {}. It should be one of these: {}"
+                     .format(repo_type, [repo_type_snapshot, repo_type_release]))
+if repo_type == 'snapshot' and len(re.findall(version_snapshot_regex, version)) == 0:
+    raise ValueError('Invalid version: {}. An artifact uploaded to a {} repository '
+                     'must have a version which complies to this regex: {}'
+                     .format(version, repo_type, version_snapshot_regex))
+if repo_type == 'release' and len(re.findall(version_release_regex, version)) == 0:
+    raise ValueError('Invalid version: {}. An artifact uploaded to a {} repository '
+                     'must have a version which complies to this regex: {}'
+                     .format(version, repo_type, version_snapshot_regex))
+
+split_artifact = os.path.basename('{artifact_path}').split('.', 1)
+
+filename = '{artifact_group}/{artifact_name}/{version}/{artifact_name}-{version}.{artifact_extension}'.format(
+    version=version, artifact_name=split_artifact[0], artifact_extension=split_artifact[1])
+
+upload(distribution_url, username, password, '{artifact_path}', filename)

--- a/distribution/templates/deploy.py
+++ b/distribution/templates/deploy.py
@@ -20,15 +20,11 @@
 #
 
 from __future__ import print_function
-from xml.etree import ElementTree
 
-import hashlib
 import os
 import re
 import subprocess as sp
 import sys
-import tempfile
-import zipfile
 from posixpath import join as urljoin
 
 # usual importing is not possible because

--- a/distribution/templates/deploy.py
+++ b/distribution/templates/deploy.py
@@ -61,10 +61,6 @@ if not username:
 if not password:
     raise ValueError('Error: password should be passed via $DEPLOY_DISTRIBUTION_PASSWORD env variable')
 
-deployment_properties = parse_deployment_properties('deployment.properties')
-distribution_url = deployment_properties['repo.distribution.' + repo_type]
-
-
 version = open("{version_file}", "r").read().strip()
 
 repo_type_snapshot = 'snapshot'
@@ -88,5 +84,8 @@ split_artifact = os.path.basename('{artifact_path}').split('.', 1)
 
 filename = '{artifact_group}/{artifact_name}/{version}/{artifact_name}-{version}.{artifact_extension}'.format(
     version=version, artifact_name=split_artifact[0], artifact_extension=split_artifact[1])
+
+deployment_properties = parse_deployment_properties('deployment.properties')
+distribution_url = deployment_properties['repo.distribution.' + repo_type]
 
 upload(distribution_url, username, password, '{artifact_path}', filename)

--- a/distribution/templates/deploy.py
+++ b/distribution/templates/deploy.py
@@ -48,14 +48,10 @@ def upload(url, username, password, local_fn, remote_fn):
             local_fn, upload_status_code))
 
 
-def unpack_args(_, a):
-    return a
+if len(sys.argv) != 2:
+    raise ValueError('Should pass only <snapshot|release> as arguments')
 
-
-if len(sys.argv) < 2:
-    raise ValueError('Should pass <snapshot|release> as arguments')
-
-repo_type = unpack_args(*sys.argv)
+_, repo_type = sys.argv
 
 username, password = os.getenv('DEPLOY_DISTRIBUTION_USERNAME'), os.getenv('DEPLOY_DISTRIBUTION_PASSWORD')
 

--- a/doc_hub.bzl
+++ b/doc_hub.bzl
@@ -94,3 +94,6 @@ deploy_pip = d
 load("//rpm:rules.bzl", a = "assemble_rpm", d = "deploy_rpm")
 assemble_rpm = a
 deploy_rpm = d
+
+load("//distribution:rules.bzl", d = "deploy_distribution")
+deploy_distribution = d


### PR DESCRIPTION
## What is the goal of this PR?

Since many of our tests rely on separately executable artifacts (mainly grakn) that should not share any dependencies with the tested artifact, we want to be able to deploy versioned snapshot and release artifacts built for specific commits with the correct versions of dependencies so that tests can properly run against a static version that will not change due to overlaid bazel dependencies.

This requires writing a bazel rule that will publish some archive/file to a raw repository, which is the goal of this PR.

## What are the changes implemented in this PR?

- Added `deploy_distribution` rule that publishes a single artifact to a raw repo.