### PR TITLE
add '-sources.jar' as potential srcjar

### DIFF
--- a/maven/templates/rules.bzl
+++ b/maven/templates/rules.bzl
@@ -328,7 +328,7 @@ def _assemble_maven_impl(ctx):
         jar = all_jars[0].class_jar
 
         for output in all_jars:
-            if output.source_jar.basename.endswith('-src.jar'):
+            if output.source_jar.basename.endswith('-src.jar') or output.source_jar.basename.endswith('-sources.jar'):
                 srcjar = output.source_jar
                 break
     else:


### PR DESCRIPTION
## What is the goal of this PR?

Add support for source jars generated by the `kt_jvm_library` rule.

## What are the changes implemented in this PR?

Small change to allow the source jar to end with `-sources.jar`.

#### Related:
https://github.com/bazelbuild/rules_kotlin/issues/324