### PR TITLE
Fix assemble_pip rule

### DIFF
--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -87,11 +87,11 @@ def _assemble_pip_impl(ctx):
 
     imports = []
     for j in ctx.attr.target[PyInfo].imports.to_list():
-        if not j.startswith("pypi"):
+        if 'pypi' not in j:
             imports.append(j)
 
     for i in ctx.attr.target[PyInfo].transitive_sources.to_list():
-        if 'external/pypi' not in i.path:
+        if 'pypi' not in i.path and 'external' not in i.path:
             python_source_files.append(i)
 
     args.add_all('--files', python_source_files)


### PR DESCRIPTION
## What is the goal of this PR?

Currently, when attempting to assemble `kglib`, `assemble_pip` would (depending on a platform) either fail or produce an incorrect Python package.

## What are the changes implemented in this PR?

`assemble_pip` would no longer assume `pypi`/`external` markers will be at _start_ of package or file name, but that they might be in any part of it