### PR TITLE
Fix old skydoc dependency issue

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -18,6 +18,18 @@
 #
 
 load("@io_bazel_skydoc//stardoc:stardoc.bzl", "stardoc")
+load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+
+bzl_library(
+    name = "bzl_srcs",
+    srcs = [
+        "@rules_pkg//:pkg.bzl",
+        "@rules_pkg//:path.bzl",
+        "@rules_pkg//:rpm.bzl",
+        "@bazel_tools//tools:bzl_srcs",
+        # "@graknlabs_bazel_distribution_pip//:requirements.bzl",
+    ],
+)
 
 stardoc(
     name = "docs",
@@ -35,6 +47,7 @@ stardoc(
         "//packer:lib",
         "//pip:lib",
         "//rpm:lib",
+        ":bzl_srcs",
     ],
     symbol_names = [
         "assemble_azure",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -20,6 +20,16 @@
 workspace(name="graknlabs_bazel_distribution")
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# Load NodeJS
+http_archive(
+    name = "build_bazel_rules_nodejs",
+    sha256 = "10fffa29f687aa4d8eb6dfe8731ab5beb63811ab00981fc84a93899641fd4af1",
+    urls = ["https://github.com/bazelbuild/rules_nodejs/releases/download/2.0.3/rules_nodejs-2.0.3.tar.gz"],
+)
+load("@build_bazel_rules_nodejs//:index.bzl", "node_repositories")
+node_repositories()
 
 # Load Apt and RPM
 load("//common:dependencies.bzl", "bazelbuild_rules_pkg")
@@ -28,25 +38,21 @@ load("@rules_pkg//:deps.bzl", "rules_pkg_dependencies")
 rules_pkg_dependencies()
 
 # Load Docker
-git_repository(
-    name = "io_bazel_skydoc",
-    remote = "https://github.com/graknlabs/skydoc.git",
-    branch = "experimental-skydoc-allow-dep-on-bazel-tools",
-)
-load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
-skydoc_repositories()
-load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
-rules_sass_dependencies()
-load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
-sass_repositories()
+# git_repository(
+#     name = "io_bazel_skydoc",
+#     remote = "https://github.com/graknlabs/skydoc.git",
+#     branch = "experimental-skydoc-allow-dep-on-bazel-tools",
+# )
+# load("@io_bazel_skydoc//:setup.bzl", "skydoc_repositories")
+# skydoc_repositories()
+# load("@io_bazel_rules_sass//:package.bzl", "rules_sass_dependencies")
+# rules_sass_dependencies()
+# load("@io_bazel_rules_sass//:defs.bzl", "sass_repositories")
+# sass_repositories()
 
 # Load Github
 load("//github:dependencies.bzl", "tcnksm_ghr")
 tcnksm_ghr()
-
-# Load NodeJS
-load("@build_bazel_rules_nodejs//:defs.bzl", "node_repositories")
-node_repositories()
 
 # Load Python
 git_repository(
@@ -62,3 +68,11 @@ pip_import(
 )
 load("@graknlabs_bazel_distribution_pip//:requirements.bzl", graknlabs_bazel_distribution_pip_install = "pip_install")
 graknlabs_bazel_distribution_pip_install()
+
+git_repository(
+    name = "io_bazel_skydoc",
+    remote = "https://github.com/bazelbuild/stardoc",
+    commit = "87dc99cfe1baa9255c607ac0229bfd33a65367f5",
+)
+load("@io_bazel_skydoc//:setup.bzl", "stardoc_repositories")
+stardoc_repositories()

--- a/doc_hub.bzl
+++ b/doc_hub.bzl
@@ -65,7 +65,6 @@ assemble_gcp = _
 load('//github:rules.bzl', _ = "deploy_github")
 deploy_github = _
 
-
 load("//npm:rules.bzl", a = "assemble_npm", d = "deploy_npm")
 assemble_npm = a
 deploy_npm = d
@@ -74,9 +73,9 @@ load("//packer:rules.bzl", a = "assemble_packer", d = "deploy_packer")
 assemble_packer = a
 deploy_packer = d
 
-load("//pip:rules.bzl", a = "assemble_pip", d = "deploy_pip")
-assemble_pip = a
-deploy_pip = d
+# load("//pip:rules.bzl", a = "assemble_pip", d = "deploy_pip")
+# assemble_pip = a
+# deploy_pip = d
 
 load("//rpm:rules.bzl", a = "assemble_rpm", d = "deploy_rpm")
 assemble_rpm = a

--- a/npm/rules.bzl
+++ b/npm/rules.bzl
@@ -74,7 +74,7 @@ assemble_npm = rule(
             cfg = "host"
         ),
         "_npm": attr.label(
-            default = Label("@nodejs//:bin/npm"),
+            default = Label("@nodejs//:node"),
             allow_files = True
         )
     },
@@ -134,7 +134,7 @@ deploy_npm = rule(
             default = "//common:common.py"
         ),
         "_npm": attr.label(
-            default = Label("@nodejs//:bin/npm"),
+            default = Label("@nodejs//:node"),
             allow_files = True
         ),
     },


### PR DESCRIPTION
## What is the goal of this PR?

We depend on a custom fork of skydoc, which in turn depends on a custom fork of bazel, in order to get skydoc to be able to correctly read "non-public" source dependencies of `.bzl` files from other repos. This causes an issue because skydoc (now stardoc) depends on old versions of `nodejs_rules` that are not forwards compatible, which causes our `npm` rules and anyone who depends on them to only be available for old `nodejs_rules` users.

## What are the changes implemented in this PR?

- Updated dependency on `nodejs_rules`
- Updated dependency on `stardoc`, formerly our fork of `skydoc`
- Fixed the visibility issue by depending on sources directly in a `bzl_library` target for `stardoc` to be able to see them on some deps root.
