### PR TITLE
Make `assemble-npm` function correctly when run with RBE

### DIFF
--- a/npm/rules.bzl
+++ b/npm/rules.bzl
@@ -38,7 +38,7 @@ def _assemble_npm_impl(ctx):
         version_file = ctx.file.version_file
 
     args = ctx.actions.args()
-    args.add('--package', ctx.files.target[0].path)
+    args.add('--package', ctx.files.target.label.package)
     args.add('--output', ctx.outputs.npm_package.path)
     args.add('--version_file', version_file.path)
 


### PR DESCRIPTION
## What is the goal of this PR?
To correctly run `assemble-npm` on both local and RBE (even though this target is NOT rbe-compatible, as it produces directories), we modify the path that is passed into the `assemble-npm` python `assemble.py` implementation.

## What are the changes implemented in this PR?
* Use target label package instead of target[0].path