### PR TITLE
Update npm rules - revert use of target package path

### DIFF
--- a/npm/assemble.py
+++ b/npm/assemble.py
@@ -39,6 +39,7 @@ with open(args.version_file) as version_file:
     version = version_file.read().strip()
 
 new_package_root = tempfile.mktemp()
+
 shutil.copytree(args.package, new_package_root,
                 ignore=lambda _, names: list(
                     filter(lambda x: 'external' in x, names)))

--- a/npm/rules.bzl
+++ b/npm/rules.bzl
@@ -47,9 +47,7 @@ def _assemble_npm_impl(ctx):
         outputs = [ctx.outputs.npm_package],
         arguments = [args],
         executable = ctx.executable._assemble_script,
-        execution_requirements = {
-            "local": "1"
-        }
+        # note: do not run in RBE
     )
 
 
@@ -81,7 +79,7 @@ assemble_npm = rule(
     outputs = {
           "npm_package": "%{name}.tar.gz",
     },
-    doc = "Assemble `npm_package` target for further deployment"
+    doc = "Assemble `npm_package` target for further deployment. Currently does not support remote execution (RBE)."
 )
 
 

--- a/npm/rules.bzl
+++ b/npm/rules.bzl
@@ -38,7 +38,7 @@ def _assemble_npm_impl(ctx):
         version_file = ctx.file.version_file
 
     args = ctx.actions.args()
-    args.add('--package', ctx.attr.target.label.package)
+    args.add('--package', ctx.files.target[0].path)
     args.add('--output', ctx.outputs.npm_package.path)
     args.add('--version_file', version_file.path)
 

--- a/npm/rules.bzl
+++ b/npm/rules.bzl
@@ -38,7 +38,7 @@ def _assemble_npm_impl(ctx):
         version_file = ctx.file.version_file
 
     args = ctx.actions.args()
-    args.add('--package', ctx.files.target[0].path)
+    args.add('--package', ctx.files.target.label.package)
     args.add('--output', ctx.outputs.npm_package.path)
     args.add('--version_file', version_file.path)
 

--- a/npm/rules.bzl
+++ b/npm/rules.bzl
@@ -38,7 +38,7 @@ def _assemble_npm_impl(ctx):
         version_file = ctx.file.version_file
 
     args = ctx.actions.args()
-    args.add('--package', ctx.files.target.label.package)
+    args.add('--package', ctx.attr.target.label.package)
     args.add('--output', ctx.outputs.npm_package.path)
     args.add('--version_file', version_file.path)
 


### PR DESCRIPTION
## What is the goal of this PR?
Prior changes #255  and #254 attempted to make RBE fail gracefully in the `assemble-npm` rules. However, this ended up not working and this PR reverts the previous PRs.

## What are the changes implemented in this PR?
* Remove `local: 1` requirements in `assemble-npm` rule implementation
* revert change to obtain contents npm package from `ctx.attr.target.label.package` to `ctx.files.target[0].path`
* Add to doc that the `assemble-npm` rule cannot be run in RBE