### PR TITLE
Fix error message for incorrect maven version

### DIFF
--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -125,7 +125,7 @@ if repo_type == 'snapshot' and len(re.findall(version_snapshot_regex, version)) 
 if repo_type == 'release' and len(re.findall(version_release_regex, version)) == 0:
     raise ValueError('Invalid version: {}. An artifact uploaded to a {} repository '
                      'must have a version which complies to this regex: {}'
-                     .format(version, repo_type, version_snapshot_regex))
+                     .format(version, repo_type, version_release_regex))
 
 filename_base = '{coordinates}/{artifact}/{version}/{artifact}-{version}'.format(
     coordinates=group_id.text.replace('.', '/'), version=version, artifact=artifact_id.text)


### PR DESCRIPTION
## What is the goal of this PR?

Fix incorrect error message referencing the wrong regex when trying to deploy an invalid release version to a maven repository:
```
An artifact uploaded to a release repository must have a version which complies to this regex: ^[0-9|a-f|A-F]{40}$
```

## What are the changes implemented in this PR?

Corrects error message to:
```
An artifact uploaded to a release repository must have a version which complies to this regex: ^[0-9]+.[0-9]+.[0-9]+$
```

