### PR TITLE
Account for cases where source JAR doesn't exist

### DIFF
--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -356,7 +356,7 @@ def _assemble_maven_impl(ctx):
         jar = all_jars[0].class_jar
 
         for output in all_jars:
-            if output.source_jar.basename.endswith('-src.jar') or output.source_jar.basename.endswith('-sources.jar'):
+            if output.source_jar and (output.source_jar.basename.endswith('-src.jar') or output.source_jar.basename.endswith('-sources.jar')):
                 srcjar = output.source_jar
                 break
     else:


### PR DESCRIPTION
## What is the goal of this PR?

Fix `assemble_maven` to allow deploying `java_import` targets

## What are the changes implemented in this PR?

Currently, when trying to deploy `java_import` targets, `assemble_maven` fails with this error:

```
Traceback (most recent call last):
	File "/home/vmax/work/graknlabs/alex-debug/dependencies/library/rocksdbjni/BUILD", line 59
		assemble_maven(name = 'assemble-maven')
	File "/home/vmax/.cache/bazel/_bazel_vmax/479536ed392db81ef53584b0e6cda650/external/graknlabs_bazel_distribution/maven/rules.bzl", line 359, in _assemble_maven_impl
		output.source_jar.basename
'NoneType' value has no field or method 'basename'
```