### PR TITLE
Allow absent srcjar in deploy_maven

### DIFF
--- a/maven/rules.bzl
+++ b/maven/rules.bzl
@@ -374,7 +374,7 @@ def _assemble_maven_impl(ctx):
     if srcjar == None:
         return [
             DefaultInfo(files = depset([output_jar, pom_file])),
-            MavenDeploymentInfo(jar = output_jar, pom = pom_file)
+            MavenDeploymentInfo(jar = output_jar, pom = pom_file, srcjar = srcjar)
         ]
     else:
         return [
@@ -478,17 +478,21 @@ def _deploy_maven_impl(ctx):
         }
     )
 
+    files = [
+        ctx.attr.target[MavenDeploymentInfo].jar,
+        ctx.attr.target[MavenDeploymentInfo].pom,
+    ]
+    symlinks = {
+        lib_jar_link: ctx.attr.target[MavenDeploymentInfo].jar,
+        pom_xml_link: ctx.attr.target[MavenDeploymentInfo].pom,
+    }
+    if ctx.attr.target[MavenDeploymentInfo].srcjar:
+        files.append(ctx.attr.target[MavenDeploymentInfo].srcjar)
+        symlinks[src_jar_link] = ctx.attr.target[MavenDeploymentInfo].srcjar
+
     return DefaultInfo(
         executable = deploy_maven_script,
-        runfiles = ctx.runfiles(files=[
-            ctx.attr.target[MavenDeploymentInfo].jar,
-            ctx.attr.target[MavenDeploymentInfo].pom,
-            ctx.attr.target[MavenDeploymentInfo].srcjar,
-        ], symlinks = {
-            lib_jar_link: ctx.attr.target[MavenDeploymentInfo].jar,
-            pom_xml_link: ctx.attr.target[MavenDeploymentInfo].pom,
-            src_jar_link: ctx.attr.target[MavenDeploymentInfo].srcjar,
-        })
+        runfiles = ctx.runfiles(files=files, symlinks = symlinks)
     )
 
 deploy_maven = rule(

--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -136,13 +136,14 @@ if should_sign:
 upload(maven_url, username, password, jar_path, filename_base + '.jar')
 if should_sign:
     upload(maven_url, username, password, sign(jar_path), filename_base + '.jar.asc')
-upload(maven_url, username, password, srcjar_path, filename_base + '-sources.jar')
-if should_sign:
-    upload(maven_url, username, password, sign(srcjar_path), filename_base + '-sources.jar.asc')
-# TODO(vmax): use real Javadoc instead of srcjar
-upload(maven_url, username, password, srcjar_path, filename_base + '-javadoc.jar')
-if should_sign:
-    upload(maven_url, username, password, sign(srcjar_path), filename_base + '-javadoc.jar.asc')
+if os.path.exists(srcjar_path):
+    upload(maven_url, username, password, srcjar_path, filename_base + '-sources.jar')
+    if should_sign:
+        upload(maven_url, username, password, sign(srcjar_path), filename_base + '-sources.jar.asc')
+    # TODO(vmax): use real Javadoc instead of srcjar
+    upload(maven_url, username, password, srcjar_path, filename_base + '-javadoc.jar')
+    if should_sign:
+        upload(maven_url, username, password, sign(srcjar_path), filename_base + '-javadoc.jar.asc')
 
 with tempfile.NamedTemporaryFile(mode='wt', delete=True) as pom_md5:
     pom_md5.write(md5(pom_file_path))
@@ -164,16 +165,17 @@ with tempfile.NamedTemporaryFile(mode='wt', delete=True) as jar_sha1:
     jar_sha1.flush()
     upload(maven_url, username, password, jar_sha1.name, filename_base + '.jar.sha1')
 
-with tempfile.NamedTemporaryFile(mode='wt', delete=True) as srcjar_md5:
-    srcjar_md5.write(md5(srcjar_path))
-    srcjar_md5.flush()
-    upload(maven_url, username, password, srcjar_md5.name, filename_base + '-sources.jar.md5')
-    # TODO(vmax): use checksum of real Javadoc instead of srcjar
-    upload(maven_url, username, password, srcjar_md5.name, filename_base + '-javadoc.jar.md5')
+if os.path.exists(srcjar_path):
+    with tempfile.NamedTemporaryFile(mode='wt', delete=True) as srcjar_md5:
+        srcjar_md5.write(md5(srcjar_path))
+        srcjar_md5.flush()
+        upload(maven_url, username, password, srcjar_md5.name, filename_base + '-sources.jar.md5')
+        # TODO(vmax): use checksum of real Javadoc instead of srcjar
+        upload(maven_url, username, password, srcjar_md5.name, filename_base + '-javadoc.jar.md5')
 
-with tempfile.NamedTemporaryFile(mode='wt', delete=True) as srcjar_sha1:
-    srcjar_sha1.write(sha1(srcjar_path))
-    srcjar_sha1.flush()
-    upload(maven_url, username, password, srcjar_sha1.name, filename_base + '-sources.jar.sha1')
-    # TODO(vmax): use checksum of real Javadoc instead of srcjar
-    upload(maven_url, username, password, srcjar_sha1.name, filename_base + '-javadoc.jar.sha1')
+    with tempfile.NamedTemporaryFile(mode='wt', delete=True) as srcjar_sha1:
+        srcjar_sha1.write(sha1(srcjar_path))
+        srcjar_sha1.flush()
+        upload(maven_url, username, password, srcjar_sha1.name, filename_base + '-sources.jar.sha1')
+        # TODO(vmax): use checksum of real Javadoc instead of srcjar
+        upload(maven_url, username, password, srcjar_sha1.name, filename_base + '-javadoc.jar.sha1')


### PR DESCRIPTION
## What is the goal of this PR?

Follow-up to #262 which tweaks `deploy_maven` to access artifacts without source jars

## What are the changes implemented in this PR?

Gracefully handle absence of source JAR while deploying
