### PR TITLE
Allow java_deps to target Maven packages and support overrides for the output path

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Assemble Java package for subsequent deployment to Maven repo
 assemble_npm(<a href="#assemble_npm-name">name</a>, <a href="#assemble_npm-target">target</a>, <a href="#assemble_npm-version_file">version_file</a>)
 </pre>
 
-Assemble `npm_package` target for further deployment
+Assemble `npm_package` target for further deployment. Currently does not support remote execution (RBE).
 
 **ATTRIBUTES**
 
@@ -319,7 +319,7 @@ Fills in JSON template with provided values
 ## java_deps
 
 <pre>
-java_deps(<a href="#java_deps-name">name</a>, <a href="#java_deps-java_deps_root">java_deps_root</a>, <a href="#java_deps-maven_name">maven_name</a>, <a href="#java_deps-target">target</a>, <a href="#java_deps-version_file">version_file</a>)
+java_deps(<a href="#java_deps-name">name</a>, <a href="#java_deps-java_deps_root">java_deps_root</a>, <a href="#java_deps-java_deps_root_overrides">java_deps_root_overrides</a>, <a href="#java_deps-maven_name">maven_name</a>, <a href="#java_deps-target">target</a>, <a href="#java_deps-version_file">version_file</a>)
 </pre>
 
 Packs Java library alongside with its dependencies into archive
@@ -331,6 +331,7 @@ Packs Java library alongside with its dependencies into archive
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="java_deps-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/docs/build-ref.html#name">Name</a> | required |  |
 | <a id="java_deps-java_deps_root"></a>java_deps_root |  Folder inside archive to put JARs into   | String | optional | "" |
+| <a id="java_deps-java_deps_root_overrides"></a>java_deps_root_overrides |  JARs with filenames matching the given patterns will be placed into the specified folders inside the archive,             instead of the default folder. Patterns can be either the full name of a JAR, or a prefix followed by a '*'.   | <a href="https://bazel.build/docs/skylark/lib/dict.html">Dictionary: String -> String</a> | optional | {} |
 | <a id="java_deps-maven_name"></a>maven_name |  Name JAR files inside archive based on Maven coordinates   | Boolean | optional | False |
 | <a id="java_deps-target"></a>target |  Java target to pack into archive   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="java_deps-version_file"></a>version_file |  File containing version string.             Alternatively, pass --define version=VERSION to Bazel invocation.             Not specifying version at all defaults to '0.0.0'   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |

--- a/common/java_deps.bzl
+++ b/common/java_deps.bzl
@@ -125,7 +125,7 @@ def _java_deps_impl(ctx):
             for jarPattern in outputPathOverrides:
                 if file.basename == jarPattern or (jarPattern.endswith("*") and file.basename.startswith(jarPattern.rstrip("*"))):
                     names[file.path] = outputPathOverrides.get(jarPattern) + filename + ".jar"
-                    continue
+                    break
             if names.get(file.path) == None:
                 names[file.path] = ctx.attr.java_deps_root + filename + ".jar"
             files.append(file)

--- a/common/java_deps.bzl
+++ b/common/java_deps.bzl
@@ -113,7 +113,7 @@ def _java_deps_impl(ctx):
 
     mapping = ctx.attr.target[TransitiveJarToMavenCoordinatesMapping].mapping
 
-    for file in ctx.attr.target.data_runfiles.files.to_list():
+    for file in ctx.attr.target.data_runfiles.files.to_list() + ctx.attr.target.files.to_list():
         if file.extension == 'jar' and not file.path.startswith(LOCAL_JDK_PREFIX):
             if ctx.attr.maven_name and file.path not in mapping:
                 fail("{} does not have associated Maven coordinate".format(file.owner))

--- a/common/java_deps.bzl
+++ b/common/java_deps.bzl
@@ -124,9 +124,9 @@ def _java_deps_impl(ctx):
                 continue # do not pack JARs with same name
             for jarPattern in outputPathOverrides:
                 if file.basename == jarPattern or (jarPattern.endswith("*") and file.basename.startswith(jarPattern.rstrip("*"))):
-                    names[file.path] = outputPathOverrides.get(jarPattern) + filename + ".jar"
+                    names[file.path] = outputPathOverrides[jarPattern] + filename + ".jar"
                     break
-            if names.get(file.path) == None:
+            if file.path not in names:
                 names[file.path] = ctx.attr.java_deps_root + filename + ".jar"
             files.append(file)
             filenames.append(filename)


### PR DESCRIPTION
## What is the goal of this PR?

To allow Grakn 2.0 to output rocksdb-dev to lib/dev and rocksdb-prod to lib/prod when building a Grakn distribution.

## What are the changes implemented in this PR?

Firstly, we need to be able to target Maven packages using `java_deps`. We add support for this by looking through both `ctx.attr.target.data_runfiles.files` and `ctx.attr.target.files`.

We also add support for `java_deps` to have output path overrides. When a JAR matching the given pattern is found, it is deployed to the folder specified in the override, instead of the default output folder.