### PR TITLE
Allow snapshot artifacts to use short (7 char) SHA

### DIFF
--- a/artifact/templates/deploy.py
+++ b/artifact/templates/deploy.py
@@ -58,7 +58,7 @@ if not password:
 version = open("{version_file}", "r").read().strip()
 
 snapshot = 'snapshot'
-version_snapshot_regex = '^[0-9|a-f|A-F]{40}$'
+version_snapshot_regex = '^[0-9|a-f|A-F]{7}([0-9|a-f|A-F]{33})?$'
 release = 'release'
 version_release_regex = '^[0-9]+.[0-9]+.[0-9]+$'
 


### PR DESCRIPTION
## What is the goal of this PR?

To allow Grakn to run on Linux.

When assembling the linux targz as a snapshot, the filename of the `grabl-tracing` jars are too long and get truncated, meaning Grakn cannot run properly (eg: transactions cannot be opened).

## What are the changes implemented in this PR?

Update the version regex for snapshot builds to allow short (7 character) SHAs. By default, a SHA is 40 characters long.
