### PR TITLE
Adds a parameter in deploy_github that allows for creating both a draft as well as a published release

### DIFF
--- a/github/templates/deploy.py
+++ b/github/templates/deploy.py
@@ -105,7 +105,7 @@ try:
         '-n', title,
         '-b', open('release_description.txt').read() if has_release_description else '',
         '-c', target_commit_id,
-        '-delete', '-draft', github_tag,  # TODO: tag must reference the current commit
+        '-delete', github_tag,  # TODO: tag must reference the current commit
         directory_to_upload
     ], env={'GITHUB_TOKEN': github_token})
 finally:


### PR DESCRIPTION
## What is the goal of this PR?

We have added a `draft` parameter to `deploy_github`. If it is set to `True`, the rule will create a release that is marked as draft. When set to `False`, the release will be immediately published.

This is an improvement of the existing behaviour, in which you can only create a draft release.

## What are the changes implemented in this PR?

- Implement the `draft` field
- Refactor the rule and `deploy.py` template