### PR TITLE
assemble_azure: allow for custom base image

### DIFF
--- a/azure/packer.template.json
+++ b/azure/packer.template.json
@@ -14,9 +14,9 @@
       "managed_image_name": "{image_name}",
       "managed_image_resource_group_name": "{resource_group_name}",
       "os_type": "Linux",
-      "image_publisher": "Canonical",
-      "image_offer": "0001-com-ubuntu-server-focal",
-      "image_sku": "20_04-lts",
+      "image_publisher": "{image_publisher}",
+      "image_offer": "{image_offer}",
+      "image_sku": "{image_sku}",
       "build_resource_group_name": "{resource_group_name}",
       "vm_size": "Standard_B2s"
     }

--- a/azure/rules.bzl
+++ b/azure/rules.bzl
@@ -24,6 +24,9 @@ def assemble_azure(name,
                    image_name,
                    resource_group_name,
                    install,
+                   image_publisher="Canonical",
+                   image_offer="0001-com-ubuntu-server-focal",
+                   image_sku="20_04-lts",
                    files=None):
     """Assemble files for GCP deployment
 
@@ -45,6 +48,9 @@ def assemble_azure(name,
             "{image_name}": image_name,
             "{resource_group_name}": resource_group_name,
             "{install}": install_fn,
+            "{image_publisher}": image_publisher,
+            "{image_offer}": image_offer,
+            "{image_sku}": image_sku,
         }
     )
     files[install] = install_fn


### PR DESCRIPTION
## What is the goal of this PR?

There is a need to deploy custom Azure images that are not based on Ubuntu 20.04. This PR makes image publisher, sku and offer configurable.

## What are the changes implemented in this PR?

Make it possible to configure `image_publisher`, `image_offer` and `image_sku`; leave the old hardcoded options are default for backwards compatibility.