### PR TITLE
allow conventional SNAPSHOT maven releases

### DIFF
--- a/maven/templates/deploy.py
+++ b/maven/templates/deploy.py
@@ -111,7 +111,7 @@ if version is None or len(version.text) == 0:
 version = version.text
 
 snapshot = 'snapshot'
-version_snapshot_regex = '^[0-9|a-f|A-F]{40}$'
+version_snapshot_regex = '^[0-9|a-f|A-F]{40}$|.*-SNAPSHOT$'
 release = 'release'
 version_release_regex = '^[0-9]+.[0-9]+.[0-9]+(-[a-zA-Z0-9]+)?$'
 


### PR DESCRIPTION
## What is the goal of this PR?

Allow snapshot releases with the standard -SNAPSHOT naming convention.

## What are the changes implemented in this PR?

Update the snapshot regex. I've verified the change.

Closes #230