### PR TITLE
Change naming in assemble pip

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -1,7 +1,7 @@
 build:
   correctness:
     build:
-      machine: graknlabs-ubuntu-20.04
+      image: graknlabs-ubuntu-20.04
       type: foreground
       script: |
         bazel build //...

--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ Assemble `npm_package` target for further deployment. Currently does not support
 ## assemble_pip
 
 <pre>
-assemble_pip(<a href="#assemble_pip-name">name</a>, <a href="#assemble_pip-author">author</a>, <a href="#assemble_pip-author_email">author_email</a>, <a href="#assemble_pip-classifiers">classifiers</a>, <a href="#assemble_pip-description">description</a>, <a href="#assemble_pip-install_requires_file">install_requires_file</a>, <a href="#assemble_pip-keywords">keywords</a>,
-             <a href="#assemble_pip-license">license</a>, <a href="#assemble_pip-long_description_file">long_description_file</a>, <a href="#assemble_pip-package_name">package_name</a>, <a href="#assemble_pip-target">target</a>, <a href="#assemble_pip-url">url</a>, <a href="#assemble_pip-version_file">version_file</a>)
+assemble_pip(<a href="#assemble_pip-name">name</a>, <a href="#assemble_pip-author">author</a>, <a href="#assemble_pip-author_email">author_email</a>, <a href="#assemble_pip-classifiers">classifiers</a>, <a href="#assemble_pip-description">description</a>, <a href="#assemble_pip-keywords">keywords</a>, <a href="#assemble_pip-license">license</a>,
+             <a href="#assemble_pip-long_description_file">long_description_file</a>, <a href="#assemble_pip-package_name">package_name</a>, <a href="#assemble_pip-requirements_file">requirements_file</a>, <a href="#assemble_pip-target">target</a>, <a href="#assemble_pip-url">url</a>, <a href="#assemble_pip-version_file">version_file</a>)
 </pre>
 
 
@@ -71,11 +71,11 @@ assemble_pip(<a href="#assemble_pip-name">name</a>, <a href="#assemble_pip-autho
 | <a id="assemble_pip-author_email"></a>author_email |  The email for the author   | String | required |  |
 | <a id="assemble_pip-classifiers"></a>classifiers |  A list of strings, containing Python package classifiers   | List of strings | required |  |
 | <a id="assemble_pip-description"></a>description |  A string with the short description of the package   | String | required |  |
-| <a id="assemble_pip-install_requires_file"></a>install_requires_file |  A file with the list of required packages for this one   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="assemble_pip-keywords"></a>keywords |  A list of strings, containing keywords   | List of strings | required |  |
 | <a id="assemble_pip-license"></a>license |  The type of license to use   | String | required |  |
 | <a id="assemble_pip-long_description_file"></a>long_description_file |  A label with the long description of the package. Usually a README or README.rst file   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="assemble_pip-package_name"></a>package_name |  A string with Python pip package name   | String | required |  |
+| <a id="assemble_pip-requirements_file"></a>requirements_file |  A file with the list of required packages for this one   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="assemble_pip-target"></a>target |  <code>py_library</code> label to be included in the package   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | required |  |
 | <a id="assemble_pip-url"></a>url |  A homepage for the project   | String | required |  |
 | <a id="assemble_pip-version_file"></a>version_file |  File containing version string.             Alternatively, pass --define version=VERSION to Bazel invocation.             Not specifying version at all defaults to '0.0.0'   | <a href="https://bazel.build/docs/build-ref.html#labels">Label</a> | optional | None |

--- a/pip/assemble.py
+++ b/pip/assemble.py
@@ -39,7 +39,7 @@ def create_init_files(directory):
 parser = argparse.ArgumentParser()
 parser.add_argument('--output', help="Output archive")
 parser.add_argument('--setup_py', help="setup.py")
-parser.add_argument('--install_requires_file', help="install_requires")
+parser.add_argument('--requirements_file', help="install_requires")
 parser.add_argument('--readme', help="README file")
 parser.add_argument('--files', nargs='+', help='Python files to pack into archive')
 parser.add_argument('--imports', nargs='+', help='Folders considered to be source code roots')
@@ -78,7 +78,7 @@ readme = os.path.join(pkg_dir, 'README.md')
 
 with open(args.setup_py) as setup_py_template:
     install_requires = []
-    with open(args.install_requires_file) as requirements_file:
+    with open(args.requirements_file) as requirements_file:
         for line in requirements_file.readlines():
             if not line.startswith('#') and line.strip() != '':
                 install_requires.append(line.strip())

--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -143,12 +143,12 @@ def _assemble_pip_impl(ctx):
           version_file.path, preprocessed_setup_py.path, setup_py.path)
     )
 
-    args.add("--install_requires_file", ctx.file.install_requires_file.path)
+    args.add("--requirements_file", ctx.file.requirements_file.path)
     args.add("--setup_py", setup_py.path)
     args.add_all("--imports", imports)
 
     ctx.actions.run(
-        inputs = [version_file, setup_py, ctx.file.long_description_file, ctx.file.install_requires_file] + python_source_files,
+        inputs = [version_file, setup_py, ctx.file.long_description_file, ctx.file.requirements_file] + python_source_files,
         outputs = [ctx.outputs.pip_package],
         arguments = [args],
         executable = ctx.executable._assemble_script,
@@ -257,7 +257,7 @@ assemble_pip = rule(
             mandatory = True,
             doc = "The type of license to use"
         ),
-        "install_requires_file": attr.label(
+        "requirements_file": attr.label(
             allow_single_file = True,
             mandatory = True,
             doc = "A file with the list of required packages for this one",


### PR DESCRIPTION
## What is the goal of this PR?

In order to keep the naming consistent, we need to rename `install_requires_file` attribute to `requirements_file` in `assemble_pip`. Additionally, syntax of Grabl was changed and we need to replace `machine:` with `image:`

## What are the changes implemented in this PR?

* Rename `install_requires_file` to `requirements_file` in `assemble_pip` and regenerate the docs
* Replace all `machine:` usages with `image:`
