### PR TITLE
Update grabl automation yaml syntax

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -3,7 +3,5 @@ build:
     build:
       image: graknlabs-ubuntu-20.04
       type: foreground
-      script: |
+      command: |
         bazel build //...
-  execution:
-    - build


### PR DESCRIPTION
## What is the goal of this PR?

Recently we added the support for background `monitor` script. Therefore we change the foreground job script from `script` to `command`.
