### PR TITLE
deploy_github: fill in version

### DIFF
--- a/github/templates/deploy.py
+++ b/github/templates/deploy.py
@@ -103,7 +103,7 @@ try:
         '-u', github_organisation,
         '-r', github_repository,
         '-n', title,
-        '-b', open('release_description.txt').read() if release_description else '',
+        '-b', open('release_description.txt').read().replace('{version}', github_tag) if release_description else '',
         '-c', target_commit_id,
     ]
     cmd += [ '-delete', '-draft', github_tag ] if draft else [ '-delete', github_tag ]


### PR DESCRIPTION
## What is the goal of this PR?

Sometime, release notes on GitHub need to reference the actual version that's being deployed ("install version X.Y.Z by executing this command") by referencing it with template argument "{version}"

## What are the changes implemented in this PR?

Replace the `{version}` in release description with the git tag being deployed