### PR TITLE
Fix artifact_extractor rule

### DIFF
--- a/artifact/rules.bzl
+++ b/artifact/rules.bzl
@@ -148,70 +148,32 @@ def artifact_file(name,
         **kwargs
     )
 
-script_template_tar = """\
+script_template = """\
 #!/bin/bash
 set -ex
 mkdir -p $BUILD_WORKSPACE_DIRECTORY/$1
-tar -xzf {artifact_location} -C $BUILD_WORKSPACE_DIRECTORY/$1 --strip-components=2
+ARCHIVE_TYPE="$(file --brief --dereference --mime-type {artifact_location})"
+if [ "$ARCHIVE_TYPE" == "application/zip" ]
+then
+    tmp_dir=$(mktemp -d)
+    unzip -qq {artifact_location} -d $tmp_dir
+    mv -v $tmp_dir/*/* $BUILD_WORKSPACE_DIRECTORY/$1/
+else
+    tar -xzf {artifact_location} -C $BUILD_WORKSPACE_DIRECTORY/$1 --strip-components=2
+fi
 """
 
-script_template_unzip = """\
-#!/bin/bash
-set -ex
-mkdir -p $BUILD_WORKSPACE_DIRECTORY/$1
-tmp_dir=$(mktemp -d)
-unzip -qq {artifact_location} -d $tmp_dir
-mv -v $tmp_dir/{artifact_unpacked_name}/* $BUILD_WORKSPACE_DIRECTORY/$1/
-rm -rf {artifact_unpacked_name}
-"""
 
 def _artifact_extractor_impl(ctx):
-    supported_extensions_script_map = {
-        'zip': script_template_unzip,
-        'tar.gz': script_template_tar,
-        'tgz': script_template_tar,
-        'taz': script_template_tar,
-        'tar.bz2': script_template_tar,
-        'tb2': script_template_tar,
-        'tbz': script_template_tar,
-        'tbz2': script_template_tar,
-        'tz2': script_template_tar,
-        'tar.lz': script_template_tar,
-        'tar.lzma': script_template_tar,
-        'tlz': script_template_tar,
-        'tar.lzo': script_template_tar,
-        'tar.xz': script_template_tar,
-        'txz': script_template_tar,
-        'tar.Z': script_template_tar,
-        'tar.zst': script_template_tar,
-    }
-
     artifact_file = ctx.file.artifact
     artifact_filename = artifact_file.basename
 
-    extraction_method = ctx.attr.extraction_method
-
-    if (extraction_method == 'auto'):
-        artifact_extention = None
-        for ext in supported_extensions_script_map.keys():
-            if artifact_filename.rfind(ext) == len(artifact_filename) - len(ext):
-                artifact_extention = ext
-                target_script_template = supported_extensions_script_map.get(ext)
-                artifact_unpacked_name = artifact_filename.replace('.' + ext, '')
-                break
-        
-        if artifact_extention == None:
-            fail("Extention [{extention}] is not supported by the artifiact_etractor.".format(extention = artifact_file.extension))
-    elif (extraction_method == 'tar'):
-        target_script_template = script_template_tar
-    elif (extraction_method == 'unzip'):
-        target_script_template = script_template_unzip
+    target_script_template = script_template
 
     # Emit the executable shell script.
     script = ctx.actions.declare_file("%s.sh" % ctx.label.name)
     script_content = target_script_template.format(
         artifact_location = artifact_file.short_path,
-        artifact_unpacked_name = artifact_unpacked_name
     )
 
     ctx.actions.write(script, script_content, is_executable = True)
@@ -228,11 +190,6 @@ artifact_extractor = rule(
             allow_single_file = True,
             doc = "Artifact archive to extract.",
         ),
-        "extraction_method": attr.string(
-            default = "auto",
-            values = ["unzip", "tar", "auto"],
-            doc = "the method to use for extracting the artifact."
-        )
     },
     executable = True,
 )


### PR DESCRIPTION
## What is the goal of this PR?

Fix `artifact_extractor` rule not working under Mac and simplify the implementation

## What are the changes implemented in this PR?

Unify the script for unpacking tar and zip archives into one and detect the archive type inside of it (instead of relying on the filename)