### PR TITLE
Fix assemble-pip to skip --extra-index-url lines

### DIFF
--- a/pip/assemble.py
+++ b/pip/assemble.py
@@ -80,7 +80,7 @@ with open(args.setup_py) as setup_py_template:
     install_requires = []
     with open(args.requirements_file) as requirements_file:
         for line in requirements_file.readlines():
-            if not line.startswith('#') and line.strip() != '':
+            if not line.startswith('#') and not line.startswith('--') and line.strip() != '':
                 install_requires.append(line.strip())
     with open(setup_py, 'w') as setup_py_file:
         setup_py_file.write(


### PR DESCRIPTION
## What is the goal of this PR?

Currently, adding `--extra-index-url` into `requirements_file` of `assemble_pip` would throw the following error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.8/distutils/core.py", line 225, in run_setup
    raise RuntimeError(("'distutils.core.setup()' was never called -- "
RuntimeError: 'distutils.core.setup()' was never called -- perhaps './setup.py' is not a Distutils setup script?
```

It stops users from depending on packages from repositories other that regular PyPI.

## What are the changes implemented in this PR?

Allow users of `assemble_pip` to have `--extra-index-url` line in `requirements.txt` (by ignoring it)