### PR TITLE
Adapt to new Grabl automation.yml syntax

### DIFF
--- a/.grabl/automation.yml
+++ b/.grabl/automation.yml
@@ -3,7 +3,7 @@ build:
     build:
       image: graknlabs-ubuntu-20.04
       type: foreground
-      script: |
+      command: |
         bazel build //...
   execution:
     - build


### PR DESCRIPTION
## What is the goal of this PR?

Fix `build` by adapting to newest syntax of Grabl's `automation.yml`
