### PR TITLE
Make python_repackage work with nested packages

### DIFF
--- a/pip/repackage.py
+++ b/pip/repackage.py
@@ -27,8 +27,8 @@ PACKAGE_PATTERN = re.compile("from (?P<original_package>.*) import (?:.*) as (?:
 parser = argparse.ArgumentParser()
 parser.add_argument('--src', help='Source file')
 parser.add_argument('--dest', help='Destination file')
-parser.add_argument('--pkg', help='Package to prepend')
-parser.add_argument('--all_pkgs', nargs='+', help='All packages in this source set')
+parser.add_argument('--pkg', help='Source package')
+parser.add_argument('--prefix', help='Prefix to add to Python package')
 args = parser.parse_args()
 
 with open(args.src) as srcf, open(args.dest, 'w') as destf:
@@ -37,8 +37,8 @@ with open(args.src) as srcf, open(args.dest, 'w') as destf:
         match = PACKAGE_PATTERN.match(line)
         if match:
             original_package = match.group('original_package')
-            if original_package in args.all_pkgs:
-                package = '{}.{}'.format(args.pkg, original_package)
+            if original_package == args.pkg:
+                package = '{}.{}'.format(args.prefix, original_package)
                 lines[i] = line.replace(
                     'from {}'.format(original_package),
                     'from {}'.format(package)

--- a/pip/rules.bzl
+++ b/pip/rules.bzl
@@ -23,7 +23,6 @@ load("@graknlabs_bazel_distribution_pip//:requirements.bzl", graknlabs_bazel_dis
 def _python_repackage_impl(ctx):
     outputs = []
     actions = []
-    all_packages = []
     for file in ctx.files.src:
         path = file.short_path
 
@@ -41,11 +40,8 @@ def _python_repackage_impl(ctx):
             ''
         )
 
-        # add original package root
-        all_packages.append(path.split('/')[0])
-
-        # prepend Python package folder
-        path = '{}/{}'.format(ctx.attr.package, path)
+        # prepend Python package prefix
+        path = '{}/{}'.format(ctx.attr.py_package_add_prefix, path)
 
         actions.append({
             'file': file,
@@ -58,8 +54,8 @@ def _python_repackage_impl(ctx):
 
         args.add('--src', action['file'].path)
         args.add('--dest', outputFile.path)
-        args.add('--pkg', ctx.attr.package)
-        args.add_all('--all_pkgs', all_packages)
+        args.add('--pkg', ctx.attr.src_package)
+        args.add('--prefix', ctx.attr.py_package_add_prefix)
 
         ctx.actions.run(
             inputs = [action['file']],
@@ -191,9 +187,13 @@ python_repackage = rule(
             mandatory = True,
             doc = "Python source files"
         ),
-        "package": attr.string(
+        "src_package": attr.string(
             mandatory = True,
-            doc = "New package root for files to be put in"
+            doc = "Package name whose import paths should be prefixed"
+        ),
+        "py_package_add_prefix": attr.string(
+            mandatory = True,
+            doc = "The prefix to add"
         ),
         "_repackage_script": attr.label(
             default = "//pip:repackage",


### PR DESCRIPTION
## What is the goal of this PR?

Our `python_repackage` rule failed to replace package names if they were nested packages. We fixed that by requiring the user to specify the source package name in the rule itself. The parameters to `python_repackage` are now: `src`, `src_package`, and `py_package_add_prefix`.

## What are the changes implemented in this PR?

Make python_repackage work with nested packages
