### PR TITLE
Update deploy_pip rule implementation

### DIFF
--- a/pip/templates/deploy.py
+++ b/pip/templates/deploy.py
@@ -25,7 +25,7 @@ import shutil
 import sys
 
 
-sys.path.extend(map(os.path.abspath, glob.glob('external/*/')))
+sys.path.extend(map(os.path.abspath, glob.glob('external/*/*')))
 # noinspection PyUnresolvedReferences
 import twine.commands.upload
 


### PR DESCRIPTION
## What is the goal of this PR?

Currently `deploy_pip` fails in runtime with `ModuleNotFoundError: No module named 'twine'` error

## What are the changes implemented in this PR?

Update the `sys.path` such that it no longer fails
