### PR TITLE
Fix deploy_brew rule to be compatible with Python 2

### DIFF
--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -30,7 +30,7 @@ import zipfile
 
 
 def get_distribution_url_from_formula(content):
-    url_line = next(filter(lambda l: l.lstrip().startswith('url'), content.split('\n')))
+    url_line = next(iter(filter(lambda l: l.lstrip().startswith('url'), content.split('\n'))))
     url = url_line.strip().split(' ')[1].replace('"', '')
     return url
 


### PR DESCRIPTION
## What is the goal of this PR?

Allow running `deploy_brew` with Python 2 being active system-wide

## What are the changes implemented in this PR?

Fix "TypeError: list object is not an iterator" error by making an iterator out of a list