### PR TITLE
Fix deploy_brew rule for non-zip targets

### DIFF
--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -98,18 +98,18 @@ try:
     distribution_url = get_distribution_url_from_formula(formula_content)
     print('Attempting to match the checksums of local distribution and Github distribution from "{}"...'.format(distribution_url))
     _, ext = os.path.splitext(distribution_url)
-    fn = 'distribution-github' + ext
+    filename = 'distribution-github' + ext
     sp.check_call([
         'curl',
         distribution_url,
         '--fail',
         '--location',
         '--output',
-        fn
+        filename
     ])
     if ext == '.zip':
-        verify_zip_file(fn)
-    checksum_of_distribution_github = hashlib.sha256(open(fn, 'rb').read()).hexdigest()
+        verify_zip_file(filename)
+    checksum_of_distribution_github = hashlib.sha256(open(filename, 'rb').read()).hexdigest()
     if checksum_of_distribution_local != checksum_of_distribution_github:
         print('Error - unable to proceed with deploying to brew! The checksums do not match:')
         print('- The checksum of local distribution: {}'.format(checksum_of_distribution_local))

--- a/brew/templates/deploy.py
+++ b/brew/templates/deploy.py
@@ -97,16 +97,19 @@ try:
     formula_content = formula_template.replace('{version}', version).replace('{sha256}', checksum_of_distribution_local)
     distribution_url = get_distribution_url_from_formula(formula_content)
     print('Attempting to match the checksums of local distribution and Github distribution from "{}"...'.format(distribution_url))
+    _, ext = os.path.splitext(distribution_url)
+    fn = 'distribution-github' + ext
     sp.check_call([
         'curl',
         distribution_url,
         '--fail',
         '--location',
         '--output',
-        'distribution-github.zip'
+        fn
     ])
-    verify_zip_file('distribution-github.zip')
-    checksum_of_distribution_github = hashlib.sha256(open('distribution-github.zip', 'rb').read()).hexdigest()
+    if ext == '.zip':
+        verify_zip_file(fn)
+    checksum_of_distribution_github = hashlib.sha256(open(fn, 'rb').read()).hexdigest()
     if checksum_of_distribution_local != checksum_of_distribution_github:
         print('Error - unable to proceed with deploying to brew! The checksums do not match:')
         print('- The checksum of local distribution: {}'.format(checksum_of_distribution_local))


### PR DESCRIPTION
## What is the goal of this PR?

Fix deploying non-ZIP (e.g. `.dmg` as in Grakn Workbase) targets to Homebrew repositories

## What are the changes implemented in this PR?

Detect extension of the file and only validate ZIP correctness if it's in fact a ZIP archive.