### PR TITLE
Fix producing .tar.gz archives with long filenames

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -20,7 +20,10 @@
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 
-exports_files(["bazelbuild_rules_python-export-requirements-bzl-for-stardoc.patch"])
+exports_files([
+    "bazelbuild_rules_python-export-requirements-bzl-for-stardoc.patch",
+    "bazelbuild_rules_pkg-fix-tarfile-format.patch",
+])
 
 # Stardoc is unable to generate documentation unless it can
 # load files that our rule files depends on via load(...)

--- a/bazelbuild_rules_pkg-fix-tarfile-format.patch
+++ b/bazelbuild_rules_pkg-fix-tarfile-format.patch
@@ -1,0 +1,20 @@
+---
+ archive.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/archive.py b/archive.py
+index 2a06dcf..ce8d9f6 100644
+--- a/archive.py
++++ b/archive.py
+@@ -143,7 +143,7 @@ class TarFileWriter(object):
+       # Instead, we manually re-implement gzopen from tarfile.py and set mtime.
+       self.fileobj = gzip.GzipFile(
+           filename=name, mode='w', compresslevel=9, mtime=self.default_mtime)
+-    self.tar = tarfile.open(name=name, mode=mode, fileobj=self.fileobj)
++    self.tar = tarfile.open(name=name, mode=mode, fileobj=self.fileobj, format=tarfile.USTAR_FORMAT)
+     self.members = set([])
+     self.directories = set([])
+ 
+-- 
+2.27.0
+

--- a/common/deps.bzl
+++ b/common/deps.bzl
@@ -10,7 +10,7 @@ def rules_python():
             # Force rules_python to export the requirements.bzl file in
             # order for stardoc to be able to load it during documentation
             # generation.
-            "//:bazelbuild_rules_python-export-requirements-bzl-for-stardoc.patch",
+            "@graknlabs_bazel_distribution//:bazelbuild_rules_python-export-requirements-bzl-for-stardoc.patch",
         ],
         patch_args = ["-p1"],
     )
@@ -23,4 +23,8 @@ def rules_pkg():
             "https://mirror.bazel.build/github.com/bazelbuild/rules_pkg/releases/download/0.2.5/rules_pkg-0.2.5.tar.gz",
         ],
         sha256 = "352c090cc3d3f9a6b4e676cf42a6047c16824959b438895a76c2989c6d7c246a",
+        patches = [
+            "@graknlabs_bazel_distribution//:bazelbuild_rules_pkg-fix-tarfile-format.patch"
+        ],
+        patch_args = ["-p1"],
     )


### PR DESCRIPTION
## What is the goal of this PR?

Patch `rules_pkg` in order for us to be able to build snapshot Console distribution with long filenames.

## What are the changes implemented in this PR?

Patch `rules_pkg` such that archives with long filenames are correctly produced
